### PR TITLE
hide button when input contains no text

### DIFF
--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -72,7 +72,7 @@ export function ChatInput({
   const cssClasses = useComposedCssClasses(builtInCssClasses, customCssClasses);
   const sendButtonClassNames = twMerge(
     cssClasses.sendButton,
-    input.length === 0 && "opacity-0"
+    input.length === 0 && "opacity-0 invisible"
   );
 
   const sendMessage = useCallback(async () => {


### PR DESCRIPTION
This PR fixes the issue noted here: https://yext.slack.com/archives/C05BQTW98KA/p1685991243614699. The send button is hidden when there’s nothing typed in the input, **AND it should not be clickable**. 