### PR TITLE
css bundle with tailwind preflight disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ import {
   ChatHeadlessProvider,
   HeadlessConfig,
 } from "@yext/chat-headless-react";
-import { ChatPanel } from "@yext/search-ui-react";
+import { ChatPanel } from "@yext/chat-ui-react";
 
 const config: HeadlessConfig = {
   apiKey: "<apiKey>",
@@ -40,5 +40,10 @@ export default App;
 To use the Component Library's Styling without adding Tailwind to your project, add the following import:
 
 ```tsx
-import "@yext/search-ui-react/bundle.css";
+import "@yext/chat-ui-react/bundle.css";
+```
+
+To have tailwind preflight disabled, import the following css bundle instead:
+```tsx
+import "@yext/chat-ui-react/bundle-no-resets.css";
 ```

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
       "import": "./lib/esm/index.js",
       "require": "./lib/commonjs/index.js"
     },
-    "./bundle.css": "./lib/bundle.css"
+    "./bundle.css": "./lib/bundle.css",
+    "./bundle-no-resets.css": "./lib/bundle-no-resets.css"
   },
   "license": "BSD-3-Clause",
   "files": [
@@ -37,7 +38,7 @@
     "generate-docs": "api-extractor run --local --verbose && api-documenter markdown --input-folder temp --output-folder docs && rm -rf temp",
     "generate-notices": "generate-license-file --input package.json --output ./THIRD-PARTY-NOTICES --overwrite",
     "build:js": "tsc -p tsconfig.esm.json && tsc -p tsconfig.cjs.json",
-    "build:css": "tailwindcss -o ./lib/bundle.css --minify -c tailwind.config.js",
+    "build:css": "tailwindcss -o ./lib/bundle.css --minify -c tailwind.config.js && tailwindcss -o ./lib/bundle-no-resets.css --minify -c tailwind-no-resets.config.js",
     "build": "rm -rf lib/** && npm run build:js && npm run build:css && npm run generate-docs && npm run generate-notices",
     "build-storybook": "storybook build"
   },

--- a/tailwind-no-resets.config.js
+++ b/tailwind-no-resets.config.js
@@ -1,0 +1,8 @@
+import tailwindConfig from "./tailwind.config";
+
+module.exports = {
+  ...tailwindConfig,
+  corePlugins: {
+    preflight: false
+  }
+};


### PR DESCRIPTION
tailwind preflight styles interferes with default DOM styling (this is an issue when use in Storm). export a new css bundle with resets disabled.

J=CLIP-205
TEST=manual

Remove tailwind in test-site, and import the new css bundle. see that it loads the styling as expected.