### PR TITLE
Ensures user message still render when there's a response error

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ export default App;
 
 ## Styling
 
-
 ### default styling
 
 To use the Component Library's Styling without adding Tailwind to your project, add the following import:
@@ -57,6 +56,7 @@ import "@yext/chat-ui-react/bundle-no-resets.css";
 ### custom styling
 
 Projects that use Tailwind may pass Tailwind classnames into the Chat components using the `customCssClasses` prop:
+
 ```tsx
 const customCssClasses: ChatPanelCssClasses = {
   container: "bg-blue-300"
@@ -68,7 +68,7 @@ Projects that don't use Tailwind may target the default styleless classnames add
 
 ```css
 .yext-chat-panel__container {
-  background-color: blue
+  background-color: blue;
 }
 ```
 

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -132,9 +132,9 @@ MIT License
 
 The following npm packages may be included in this product:
 
- - @yext/chat-core@0.3.2
- - @yext/chat-headless-react@0.3.2
- - @yext/chat-headless@0.3.2
+ - @yext/chat-core@0.3.3
+ - @yext/chat-headless-react@0.3.3
+ - @yext/chat-headless@0.3.3
 
 These packages each contain the following license and notice below:
 
@@ -1300,7 +1300,7 @@ SOFTWARE.
 
 The following npm packages may be included in this product:
 
- - react-redux@8.0.7
+ - react-redux@8.1.0
  - redux-thunk@2.4.2
 
 These packages each contain the following license and notice below:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/chat-ui-react",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/chat-ui-react",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-expanding-textarea": "^2.3.6",
@@ -55,7 +55,7 @@
         "typescript": "^5.0.4"
       },
       "peerDependencies": {
-        "@yext/chat-headless-react": "^0.3.2",
+        "@yext/chat-headless-react": "^0.3.3",
         "react": "^16.14 || ^17 || ^18",
         "react-dom": "^16.14 || ^17 || || ^18"
       }
@@ -9663,18 +9663,18 @@
       "dev": true
     },
     "node_modules/@yext/chat-core": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@yext/chat-core/-/chat-core-0.3.2.tgz",
-      "integrity": "sha512-x3mBw0QHwJJywWS/KyksAx+/vPCyY2tUenAXWPz2M5npBqArIb5V3BW4K0/0kIvxmuIN+lWbAdTW3oD7tKW6Ow==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@yext/chat-core/-/chat-core-0.3.3.tgz",
+      "integrity": "sha512-ddo1Lp2wwCGdF7pFXZxGTtRrSSk27KdCGqF6SmGTbM207ygbQh/wVGzGEa+Ep+TKVxpOBpL2asf7PTjQCsQHOQ==",
       "peer": true,
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
     },
     "node_modules/@yext/chat-headless": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@yext/chat-headless/-/chat-headless-0.3.2.tgz",
-      "integrity": "sha512-LlVTieoj9njm2/77DCHu0WQqLCkDx+L8roxBXQT/F8C3eGYq55HU8oZDTSnMIiNcKjMI3cVXY6vST0i/Kt9T3w==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@yext/chat-headless/-/chat-headless-0.3.3.tgz",
+      "integrity": "sha512-A4EMuAY7I3K4oWT6o+kCrBUKM0pbtSwKAIyyd+bqATMbu1SID5oFdU/+yXnd92uUlhSoeBmHa19vLhth3r/mIQ==",
       "peer": true,
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
@@ -9682,13 +9682,13 @@
       }
     },
     "node_modules/@yext/chat-headless-react": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@yext/chat-headless-react/-/chat-headless-react-0.3.2.tgz",
-      "integrity": "sha512-PSl+oChbuTmdOOCguqOj2HmVk/GGwFXGe4prAgQgObd9jpE7T3D+cYbUCJS+2A+ph/WubIIHBSDvEV8tnWVACw==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@yext/chat-headless-react/-/chat-headless-react-0.3.3.tgz",
+      "integrity": "sha512-VPFo4NAzNoYAof+bXb/Jwsx2/oHosNpReYLnxdbcKKVSL4mGsNghWxxpBHvLKMxdcktMjiG7g1A4rqdb7z/tqA==",
       "peer": true,
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
-        "@yext/chat-headless": "^0.3.2",
+        "@yext/chat-headless": "^0.3.3",
         "react": "^18.2.0",
         "react-redux": "^8.0.5"
       }
@@ -20085,9 +20085,9 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "node_modules/react-redux": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.7.tgz",
-      "integrity": "sha512-1vRQuCQI5Y2uNmrMXg81RXKiBHY3jBzvCvNmZF437O/Z9/pZ+ba2uYHbemYXb3g8rjsacBGo+/wmfrQKzMhJsg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.0.tgz",
+      "integrity": "sha512-CtHZzAOxi7GQvTph4dVLWwZHAWUjV2kMEQtk50OrN8z3gKxpWg3Tz7JfDw32N3Rpd7fh02z73cF6yZkK467gbQ==",
       "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-ui-react",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A library of React Components for powering Yext Chat integrations.",
   "author": "clippy@yext.com",
   "main": "./lib/commonjs/index.js",
@@ -80,7 +80,7 @@
     "typescript": "^5.0.4"
   },
   "peerDependencies": {
-    "@yext/chat-headless-react": "^0.3.2",
+    "@yext/chat-headless-react": "^0.3.3",
     "react": "^16.14 || ^17 || ^18",
     "react-dom": "^16.14 || ^17 || || ^18"
   },

--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -18,13 +18,14 @@ export interface ChatHeaderCssClasses {
   closeButton?: string;
 }
 
-const builtInCssClasses: Readonly<ChatHeaderCssClasses> = withStylelessCssClasses('Header', {
-  container:
-    "w-full px-4 py-3 flex justify-between bg-gradient-to-tr from-blue-600 to-blue-800 rounded-t-3xl",
-  title: "text-white text-xl font-medium",
-  restartButton: "w-8 text-white stroke-[0.2] ml-auto",
-  closeButton: "w-8 text-white hover:scale-110",
-});
+const builtInCssClasses: Readonly<ChatHeaderCssClasses> =
+  withStylelessCssClasses("Header", {
+    container:
+      "w-full px-4 py-3 flex justify-between bg-gradient-to-tr from-blue-600 to-blue-800 rounded-t-3xl",
+    title: "text-white text-xl font-medium",
+    restartButton: "w-8 text-white stroke-[0.2] ml-auto",
+    closeButton: "w-8 text-white hover:scale-110",
+  });
 
 /**
  * The props for the {@link ChatHeader} component.

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -18,13 +18,16 @@ export interface ChatInputCssClasses {
   sendButton?: string;
 }
 
-const builtInCssClasses: ChatInputCssClasses = withStylelessCssClasses('Input', {
-  container: "w-full h-fit flex flex-row relative @container",
-  textArea:
-    "w-full p-4 pr-10 border border-slate-300 disabled:bg-slate-50 rounded-3xl resize-none text-[13px] @[480px]:text-base",
-  sendButton:
-    "rounded-full p-1.5 w-8 h-8 stroke-2 text-white bg-blue-600 disabled:bg-slate-100 hover:bg-blue-800 active:scale-90 transition-all absolute right-7 bottom-2.5 @[480px]:bottom-3.5",
-});
+const builtInCssClasses: ChatInputCssClasses = withStylelessCssClasses(
+  "Input",
+  {
+    container: "w-full h-fit flex flex-row relative @container",
+    textArea:
+      "w-full p-4 pr-10 border border-slate-300 disabled:bg-slate-50 rounded-3xl resize-none text-[13px] @[480px]:text-base",
+    sendButton:
+      "rounded-full p-1.5 w-8 h-8 stroke-2 text-white bg-blue-600 disabled:bg-slate-100 hover:bg-blue-800 active:scale-90 transition-all absolute right-7 bottom-2.5 @[480px]:bottom-3.5",
+  }
+);
 
 /**
  * The props for the {@link ChatInput} component.

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -24,13 +24,17 @@ export interface ChatPanelCssClasses {
   messageBubbleCssClasses?: MessageBubbleCssClasses;
 }
 
-const builtInCssClasses: ChatPanelCssClasses = withStylelessCssClasses('Panel', {
-  container:
-    "h-full w-full flex flex-col relative rounded-3xl shadow-2xl bg-white",
-  messagesContainer:
-    "flex flex-col gap-y-1 mt-auto px-4 pb-[85px] overflow-auto",
-  inputContainer: "w-full absolute bottom-0 p-4 rounded-b-3xl backdrop-blur-lg",
-});
+const builtInCssClasses: ChatPanelCssClasses = withStylelessCssClasses(
+  "Panel",
+  {
+    container:
+      "h-full w-full flex flex-col relative rounded-3xl shadow-2xl bg-white",
+    messagesContainer:
+      "flex flex-col gap-y-1 mt-auto px-4 pb-[85px] overflow-auto",
+    inputContainer:
+      "w-full absolute bottom-0 p-4 rounded-b-3xl backdrop-blur-lg",
+  }
+);
 
 /**
  * The props for the {@link ChatPanel} component.

--- a/src/components/ChatPopUp.tsx
+++ b/src/components/ChatPopUp.tsx
@@ -28,18 +28,21 @@ export interface ChatPopUpCssClasses {
 }
 
 const fixedPosition = "fixed bottom-6 right-4 lg:bottom-14 lg:right-10 z-50 ";
-const builtInCssClasses: ChatPopUpCssClasses = withStylelessCssClasses('PopUp', {
-  container: "transition-all",
-  panel: fixedPosition + "w-80 lg:w-96 h-[75vh]",
-  panel__display: "duration-300 translate-y-0",
-  panel__hidden: "duration-300 translate-y-[20%] opacity-0 invisible",
-  button:
-    fixedPosition +
-    "p-2 w-12 h-12 lg:w-16 lg:h-16 flex justify-center items-center text-white shadow-xl rounded-full bg-gradient-to-br from-blue-600 to-blue-700 hover:-translate-y-2 duration-150",
-  button__display: "duration-300 transform translate-y-0",
-  button__hidden:
-    "duration-300 transform translate-y-[20%] opacity-0 invisible",
-});
+const builtInCssClasses: ChatPopUpCssClasses = withStylelessCssClasses(
+  "PopUp",
+  {
+    container: "transition-all",
+    panel: fixedPosition + "w-80 lg:w-96 h-[75vh]",
+    panel__display: "duration-300 translate-y-0",
+    panel__hidden: "duration-300 translate-y-[20%] opacity-0 invisible",
+    button:
+      fixedPosition +
+      "p-2 w-12 h-12 lg:w-16 lg:h-16 flex justify-center items-center text-white shadow-xl rounded-full bg-gradient-to-br from-blue-600 to-blue-700 hover:-translate-y-2 duration-150",
+    button__display: "duration-300 transform translate-y-0",
+    button__hidden:
+      "duration-300 transform translate-y-[20%] opacity-0 invisible",
+  }
+);
 
 /**
  * The props for the {@link ChatPopUp} component.

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -22,22 +22,25 @@ export interface MessageBubbleCssClasses {
   timestamp__user?: string;
 }
 
-const builtInCssClasses: MessageBubbleCssClasses = withStylelessCssClasses('MessageBubble', {
-  topContainer: "w-full animate-fade-in @container",
-  subContainer:
-    "flex flex-col @lg:flex-row @lg:items-center @lg:gap-x-2 @lg:m-1",
-  subContainer__bot: "",
-  subContainer__user: "@lg:flex-row-reverse",
-  message:
-    "peer rounded-2xl text-[13px] @[480px]:text-base p-4 w-fit max-w-[80%] prose overflow-x-auto",
-  message__bot: "text-slate-900 bg-gradient-to-tr from-slate-50 to-slate-100",
-  message__user:
-    "ml-auto @lg:ml-0 text-white bg-gradient-to-tr from-blue-600 to-blue-700",
-  timestamp:
-    "w-fit my-0.5 text-slate-400 text-[13px] opacity-0 peer-hover:opacity-100 duration-200 whitespace-pre-wrap",
-  timestamp__bot: "",
-  timestamp__user: "ml-auto",
-});
+const builtInCssClasses: MessageBubbleCssClasses = withStylelessCssClasses(
+  "MessageBubble",
+  {
+    topContainer: "w-full animate-fade-in @container",
+    subContainer:
+      "flex flex-col @lg:flex-row @lg:items-center @lg:gap-x-2 @lg:m-1",
+    subContainer__bot: "",
+    subContainer__user: "@lg:flex-row-reverse",
+    message:
+      "peer rounded-2xl text-[13px] @[480px]:text-base p-4 w-fit max-w-[80%] prose overflow-x-auto",
+    message__bot: "text-slate-900 bg-gradient-to-tr from-slate-50 to-slate-100",
+    message__user:
+      "ml-auto @lg:ml-0 text-white bg-gradient-to-tr from-blue-600 to-blue-700",
+    timestamp:
+      "w-fit my-0.5 text-slate-400 text-[13px] opacity-0 peer-hover:opacity-100 duration-200 whitespace-pre-wrap",
+    timestamp__bot: "",
+    timestamp__user: "ml-auto",
+  }
+);
 
 /**
  * The props for the {@link MessageBubble} component.

--- a/src/hooks/useDefaultHandleApiError.ts
+++ b/src/hooks/useDefaultHandleApiError.ts
@@ -1,7 +1,4 @@
-import {
-  MessageSource,
-  useChatActions,
-} from "@yext/chat-headless-react";
+import { MessageSource, useChatActions } from "@yext/chat-headless-react";
 import { useCallback } from "react";
 
 /**
@@ -12,14 +9,14 @@ import { useCallback } from "react";
  */
 export function useDefaultHandleApiError() {
   const chat = useChatActions();
-  
+
   return useCallback(
     (e: unknown) => {
       console.error(e);
       chat.addMessage({
-          text: "Sorry, I'm unable to respond at the moment. Please try again later!",
-          source: MessageSource.BOT,
-          timestamp: new Date().toISOString(),
+        text: "Sorry, I'm unable to respond at the moment. Please try again later!",
+        source: MessageSource.BOT,
+        timestamp: new Date().toISOString(),
       });
     },
     [chat]

--- a/src/hooks/useDefaultHandleApiError.ts
+++ b/src/hooks/useDefaultHandleApiError.ts
@@ -1,7 +1,6 @@
 import {
   MessageSource,
   useChatActions,
-  useChatState,
 } from "@yext/chat-headless-react";
 import { useCallback } from "react";
 
@@ -13,20 +12,16 @@ import { useCallback } from "react";
  */
 export function useDefaultHandleApiError() {
   const chat = useChatActions();
-  const messages = useChatState((s) => s.conversation.messages);
-
+  
   return useCallback(
     (e: unknown) => {
       console.error(e);
-      chat.setMessages([
-        ...messages,
-        {
+      chat.addMessage({
           text: "Sorry, I'm unable to respond at the moment. Please try again later!",
           source: MessageSource.BOT,
           timestamp: new Date().toISOString(),
-        },
-      ]);
+      });
     },
-    [chat, messages]
+    [chat]
   );
 }

--- a/src/utils/withStylelessCssClasses.ts
+++ b/src/utils/withStylelessCssClasses.ts
@@ -1,16 +1,16 @@
 /**
  * Append styleless css classnames that user can target to add custom styling to components.
  * The classes follows a format of "yext-chat-component-name__css-interface-field-name".
- * 
+ *
  * @example
  * the styleless css class name for {@link MessageBubble}'s "message__bot" field defined
  * in its {@link MessageBubbleCssClasses} interface is "yext-chat-message-bubble__message__bot"
- * 
+ *
  * @internal
- * 
+ *
  * @param componentName - the component name
  * @param builtInClasses - built in css classnames of the component
- * 
+ *
  * @returns builtInClasses with styleless css classnames
  */
 export function withStylelessCssClasses<
@@ -19,10 +19,13 @@ export function withStylelessCssClasses<
   componentName: string,
   builtInClasses: Readonly<ClassInterface>
 ): ClassInterface {
-  const formatString = (str: string) => str.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
-  const classes = { ...builtInClasses }
+  const formatString = (str: string) =>
+    str.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
+  const classes = { ...builtInClasses };
   Object.keys(builtInClasses).forEach((key) => {
-    classes[key] = `${classes[key]} yext-chat${formatString(componentName)}__${formatString(key)}`
-  })
+    classes[key] = `${classes[key]} yext-chat${formatString(
+      componentName
+    )}__${formatString(key)}`;
+  });
   return classes;
 }

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -23,7 +23,7 @@
     },
     "..": {
       "name": "@yext/chat-ui-react",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-expanding-textarea": "^2.3.6",
@@ -72,7 +72,7 @@
         "typescript": "^5.0.4"
       },
       "peerDependencies": {
-        "@yext/chat-headless-react": "^0.3.2",
+        "@yext/chat-headless-react": "^0.3.3",
         "react": "^16.14 || ^17 || ^18",
         "react-dom": "^16.14 || ^17 || || ^18"
       }

--- a/test-site/src/index.css
+++ b/test-site/src/index.css
@@ -4,5 +4,5 @@
 
 /* For testing styleless classnames */
 .yext-chat-header__title {
-  color: yellow
+  color: yellow;
 }

--- a/tests/components/ChatInput.test.tsx
+++ b/tests/components/ChatInput.test.tsx
@@ -117,9 +117,9 @@ it("logs request error and add an error message to state by default", async () =
   expect(consoleErrorSpy).toBeCalledWith("API Error");
   expect(chatActionsSpy.addMessage).toBeCalledTimes(1);
   expect(chatActionsSpy.addMessage).toBeCalledWith({
-      text: "Sorry, I'm unable to respond at the moment. Please try again later!",
-      source: MessageSource.BOT,
-      timestamp: expect.any(String),
+    text: "Sorry, I'm unable to respond at the moment. Please try again later!",
+    source: MessageSource.BOT,
+    timestamp: expect.any(String),
   });
 });
 

--- a/tests/components/ChatInput.test.tsx
+++ b/tests/components/ChatInput.test.tsx
@@ -106,7 +106,7 @@ it("disables stream behavior when stream prop is false", async () => {
 it("logs request error and add an error message to state by default", async () => {
   mockChatActions({
     streamNextMessage: jest.fn(() => Promise.reject("API Error")),
-    setMessages: jest.fn(),
+    addMessage: jest.fn(),
   });
   const chatActionsSpy = spyOnActions();
   const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
@@ -115,14 +115,12 @@ it("logs request error and add an error message to state by default", async () =
   await act(() => userEvent.click(sendButton));
   expect(consoleErrorSpy).toBeCalledTimes(1);
   expect(consoleErrorSpy).toBeCalledWith("API Error");
-  expect(chatActionsSpy.setMessages).toBeCalledTimes(1);
-  expect(chatActionsSpy.setMessages).toBeCalledWith([
-    {
+  expect(chatActionsSpy.addMessage).toBeCalledTimes(1);
+  expect(chatActionsSpy.addMessage).toBeCalledWith({
       text: "Sorry, I'm unable to respond at the moment. Please try again later!",
       source: MessageSource.BOT,
       timestamp: expect.any(String),
-    },
-  ]);
+  });
 });
 
 it("executes custom handleError if provided", async () => {

--- a/tests/components/ChatPanel.test.tsx
+++ b/tests/components/ChatPanel.test.tsx
@@ -46,20 +46,18 @@ it("send request to get initial message on load (non-stream)", () => {
 it("logs request error and add an error message to state by default", async () => {
   mockChatActions({
     streamNextMessage: jest.fn(() => Promise.reject("API Error")),
-    setMessages: jest.fn(),
+    addMessage: jest.fn(),
   });
   const chatActionsSpy = spyOnActions();
   const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
   render(<ChatPanel />);
   await waitFor(() => expect(consoleErrorSpy).toBeCalledTimes(1));
   expect(consoleErrorSpy).toBeCalledWith("API Error");
-  expect(chatActionsSpy.setMessages).toBeCalledWith([
-    {
-      text: "Sorry, I'm unable to respond at the moment. Please try again later!",
-      source: MessageSource.BOT,
-      timestamp: expect.any(String),
-    },
-  ]);
+  expect(chatActionsSpy.addMessage).toBeCalledWith({
+    text: "Sorry, I'm unable to respond at the moment. Please try again later!",
+    source: MessageSource.BOT,
+    timestamp: expect.any(String),
+  });
 });
 
 it("executes custom handleError if provided", async () => {

--- a/tests/utils/withStylelessCssClasses.ts
+++ b/tests/utils/withStylelessCssClasses.ts
@@ -1,14 +1,16 @@
-import { withStylelessCssClasses } from "../../src/utils/withStylelessCssClasses"
+import { withStylelessCssClasses } from "../../src/utils/withStylelessCssClasses";
 
 it("generates styleless css classnames as expected", () => {
   const classes = withStylelessCssClasses("SomeComponent", {
     container: "",
     container__someSpecificField: "p-4",
-    container__topField__subField: "border flex flex-col"
-  })
+    container__topField__subField: "border flex flex-col",
+  });
   expect(classes).toEqual({
     container: "yext-chat-some-component__container",
-    container__someSpecificField: "p-4 yext-chat-some-component__container__some-specific-field",
-    container__topField__subField: "border flex flex-col yext-chat-some-component__container__top-field__sub-field"
-  })
-})
+    container__someSpecificField:
+      "p-4 yext-chat-some-component__container__some-specific-field",
+    container__topField__subField:
+      "border flex flex-col yext-chat-some-component__container__top-field__sub-field",
+  });
+});


### PR DESCRIPTION
use `addMessage` from headless instead of `setMessages` to avoid updating with stale state.

J=CLIP-245
TEST=manual

trigger an invalid API key error upon sending a user message. See that the user's message is rendered as well as the default error message.