### PR TITLE
UI QA feedback updates

### DIFF
--- a/docs/chat-ui-react.messagebubbleprops.formattimestamp.md
+++ b/docs/chat-ui-react.messagebubbleprops.formattimestamp.md
@@ -4,7 +4,7 @@
 
 ## MessageBubbleProps.formatTimestamp property
 
-A function which is called to format the message's timestamp given in ISO format (e.g. "2023-05-18T19:33:34.553Z"). Defaults to "HH:MM:SS A" (e.g. "7:33:34 PM").
+A function which is called to format the message's timestamp given in ISO format (e.g. "2023-05-18T19:33:34.553Z"). Defaults to "HH:MM A" (e.g. "7:33 PM").
 
 **Signature:**
 

--- a/docs/chat-ui-react.messagebubbleprops.md
+++ b/docs/chat-ui-react.messagebubbleprops.md
@@ -17,7 +17,7 @@ export interface MessageBubbleProps
 |  Property | Modifiers | Type | Description |
 |  --- | --- | --- | --- |
 |  [customCssClasses?](./chat-ui-react.messagebubbleprops.customcssclasses.md) |  | [MessageBubbleCssClasses](./chat-ui-react.messagebubblecssclasses.md) | _(Optional)_ CSS classes for customizing the component styling. |
-|  [formatTimestamp?](./chat-ui-react.messagebubbleprops.formattimestamp.md) |  | (timestamp: string) =&gt; string | _(Optional)_ A function which is called to format the message's timestamp given in ISO format (e.g. "2023-05-18T19:33:34.553Z"). Defaults to "HH:MM:SS A" (e.g. "7:33:34 PM"). |
+|  [formatTimestamp?](./chat-ui-react.messagebubbleprops.formattimestamp.md) |  | (timestamp: string) =&gt; string | _(Optional)_ A function which is called to format the message's timestamp given in ISO format (e.g. "2023-05-18T19:33:34.553Z"). Defaults to "HH:MM A" (e.g. "7:33 PM"). |
 |  [message](./chat-ui-react.messagebubbleprops.message.md) |  | Message | The message to display. |
 |  [showTimestamp?](./chat-ui-react.messagebubbleprops.showtimestamp.md) |  | boolean | _(Optional)_ Whether to show the timestamp of the message with the message bubble. Defaults to true. |
 

--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -22,7 +22,7 @@ const builtInCssClasses: Readonly<ChatHeaderCssClasses> =
   withStylelessCssClasses("Header", {
     container:
       "w-full px-4 py-3 flex justify-between bg-gradient-to-tr from-blue-600 to-blue-800 rounded-t-3xl",
-    title: "text-white text-xl font-medium truncate",
+    title: "text-white text-xl font-medium truncate pr-1",
     restartButton: "w-8 text-white stroke-[0.2] ml-auto shrink-0",
     closeButton: "w-8 text-white hover:scale-110 shrink-0",
   });

--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -22,9 +22,9 @@ const builtInCssClasses: Readonly<ChatHeaderCssClasses> =
   withStylelessCssClasses("Header", {
     container:
       "w-full px-4 py-3 flex justify-between bg-gradient-to-tr from-blue-600 to-blue-800 rounded-t-3xl",
-    title: "text-white text-xl font-medium",
-    restartButton: "w-8 text-white stroke-[0.2] ml-auto",
-    closeButton: "w-8 text-white hover:scale-110",
+    title: "text-white text-xl font-medium truncate",
+    restartButton: "w-8 text-white stroke-[0.2] ml-auto shrink-0",
+    closeButton: "w-8 text-white hover:scale-110 shrink-0",
   });
 
 /**

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -23,9 +23,9 @@ const builtInCssClasses: ChatInputCssClasses = withStylelessCssClasses(
   {
     container: "w-full h-fit flex flex-row relative @container",
     textArea:
-      "w-full p-4 pr-10 border border-slate-300 disabled:bg-slate-50 rounded-3xl resize-none text-[13px] @[480px]:text-base",
+      "w-full p-4 pr-12 border border-slate-300 disabled:bg-slate-50 rounded-3xl resize-none text-[13px] @[480px]:text-base",
     sendButton:
-      "rounded-full p-1.5 w-8 h-8 stroke-2 text-white bg-blue-600 disabled:bg-slate-100 hover:bg-blue-800 active:scale-90 transition-all absolute right-7 bottom-2.5 @[480px]:bottom-3.5",
+      "rounded-full p-1.5 w-8 h-8 stroke-2 text-white bg-blue-600 disabled:bg-slate-100 hover:bg-blue-800 active:scale-90 transition-all absolute right-4 bottom-2.5 @[480px]:bottom-3.5",
   }
 );
 

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -36,7 +36,7 @@ const builtInCssClasses: MessageBubbleCssClasses = withStylelessCssClasses(
     message__user:
       "ml-auto @lg:ml-0 text-white bg-gradient-to-tr from-blue-600 to-blue-700",
     timestamp:
-      "w-fit my-0.5 text-slate-400 text-[13px] opacity-0 peer-hover:opacity-100 duration-200 whitespace-pre-wrap",
+      "w-fit my-0.5 ml-4 @lg:ml-0 text-slate-400 text-[10px] @[480px]:text-[13px] opacity-0 peer-hover:opacity-100 duration-200 whitespace-pre-wrap",
     timestamp__bot: "",
     timestamp__user: "ml-auto",
   }
@@ -58,7 +58,7 @@ export interface MessageBubbleProps {
   /**
    * A function which is called to format the message's timestamp given in
    * ISO format (e.g. "2023-05-18T19:33:34.553Z").
-   * Defaults to "HH:MM:SS A" (e.g. "7:33:34 PM").
+   * Defaults to "HH:MM A" (e.g. "7:33 PM").
    */
   formatTimestamp?: (timestamp: string) => string;
   /** CSS classes for customizing the component styling. */
@@ -116,7 +116,7 @@ export function MessageBubble({
 }
 
 /**
- * Formats message's timestamp from "2023-05-18T19:33:34.553Z" to "7:33:34 PM"
+ * Formats message's timestamp from "2023-05-18T19:33:34.553Z" to "7:33 PM"
  *
  * @param timestamp - the timestamp to convert from
  * @returns formatted timestamp
@@ -125,7 +125,6 @@ function defaultFormatTimestamp(timestamp: string): string {
   return new Date(timestamp).toLocaleString(undefined, {
     hour: "numeric",
     minute: "numeric",
-    second: "numeric",
     hour12: true,
   });
 }

--- a/tests/components/MessageBubble.test.tsx
+++ b/tests/components/MessageBubble.test.tsx
@@ -8,7 +8,7 @@ const dummyMessage: Message = {
   source: MessageSource.USER,
 };
 
-const timestampRegex = /\d{1,2}:\d\d:\d\d (AM|PM)/;
+const timestampRegex = /\d{1,2}:\d\d (AM|PM)/;
 it("displays message as expected", () => {
   render(<MessageBubble message={dummyMessage} />);
   expect(screen.getByText(dummyMessage.text)).toBeInTheDocument();


### PR DESCRIPTION
addressed some QA feedback

J=CLIP-248,CLIP-249,CLIP-267
TEST=manual

timestamp:
before:
![Screenshot 2023-06-16 at 5 08 06 PM](https://github.com/yext/chat-ui-react/assets/36055303/8dfd7f3a-eb31-43da-94d5-77e910242aae)
after:
![Screenshot 2023-06-16 at 5 04 55 PM](https://github.com/yext/chat-ui-react/assets/36055303/4c97ff9d-4b73-4ebd-8759-48f2d213308d)

header truncation:
before:
![Screenshot 2023-06-16 at 5 08 50 PM](https://github.com/yext/chat-ui-react/assets/36055303/851ebcd8-3d67-4a24-a2f9-ae31a1a6ffa7)
after:
![Screenshot 2023-06-16 at 5 06 32 PM](https://github.com/yext/chat-ui-react/assets/36055303/c74130ae-daa8-456c-a6bd-294dae2b4686)

send button position:
before:
![Screenshot 2023-06-16 at 5 09 15 PM](https://github.com/yext/chat-ui-react/assets/36055303/51855352-7dd1-41ff-a32b-fddf361645ad)
after:
![Screenshot 2023-06-16 at 5 07 05 PM](https://github.com/yext/chat-ui-react/assets/36055303/e376edc7-8a10-44aa-9daa-b725e5af6ef0)
