### PR TITLE
disable send button on empty input

### DIFF
--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -124,7 +124,7 @@ export function ChatInput({
       />
       <button
         aria-label="Send Message"
-        disabled={!canSendMessage}
+        disabled={!canSendMessage || input.length === 0}
         onClick={sendMessage}
         className={cssClasses.sendButton}
       >

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -31,6 +31,9 @@ const builtInCssClasses: ChatPanelCssClasses = withStylelessCssClasses(
     messagesContainer:
       "flex flex-col gap-y-1 mt-auto px-4 pb-[85px] overflow-auto",
     inputContainer: "w-full absolute bottom-0 p-4 backdrop-blur-lg",
+    messageBubbleCssClasses: {
+      topContainer: "first:mt-4",
+    }
   }
 );
 

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -33,7 +33,7 @@ const builtInCssClasses: ChatPanelCssClasses = withStylelessCssClasses(
     inputContainer: "w-full absolute bottom-0 p-4 backdrop-blur-lg",
     messageBubbleCssClasses: {
       topContainer: "first:mt-4",
-    }
+    },
   }
 );
 

--- a/tests/components/ChatInput.test.tsx
+++ b/tests/components/ChatInput.test.tsx
@@ -110,10 +110,21 @@ it("disables send button when canSendMessage is false", () => {
   expect(screen.getByRole("button")).toBeDisabled();
 });
 
+it("disables send button when input is empty", () => {
+  mockChatState({
+    conversation: {
+      canSendMessage: true,
+    },
+  });
+  render(<ChatInput />);
+  expect(screen.getByRole("button")).toBeDisabled();
+});
+
 it("enables stream behavior by default", async () => {
   render(<ChatInput />);
   const actions = spyOnActions();
 
+  await act(() => userEvent.type(screen.getByRole("textbox"), "test"));
   const sendButton = screen.getByRole("button");
   await act(() => userEvent.click(sendButton));
   expect(actions.streamNextMessage).toBeCalledTimes(1);
@@ -124,6 +135,7 @@ it("disables stream behavior when stream prop is false", async () => {
   render(<ChatInput stream={false} />);
   const actions = spyOnActions();
 
+  await act(() => userEvent.type(screen.getByRole("textbox"), "test"));
   const sendButton = screen.getByRole("button");
   await act(() => userEvent.click(sendButton));
   expect(actions.streamNextMessage).toBeCalledTimes(0);
@@ -138,6 +150,7 @@ it("logs request error and add an error message to state by default", async () =
   const chatActionsSpy = spyOnActions();
   const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
   render(<ChatInput />);
+  await act(() => userEvent.type(screen.getByRole("textbox"), "test"));
   const sendButton = screen.getByRole("button");
   await act(() => userEvent.click(sendButton));
   expect(consoleErrorSpy).toBeCalledTimes(1);
@@ -156,6 +169,7 @@ it("executes custom handleError if provided", async () => {
   });
   const customHandleError = jest.fn();
   render(<ChatInput handleError={customHandleError} />);
+  await act(() => userEvent.type(screen.getByRole("textbox"), "test"));
   const sendButton = screen.getByRole("button");
   await act(() => userEvent.click(sendButton));
   expect(customHandleError).toBeCalledTimes(1);

--- a/tests/components/ChatPopUp.stories.tsx
+++ b/tests/components/ChatPopUp.stories.tsx
@@ -24,8 +24,8 @@ export const PopupButton: StoryObj<typeof meta> = {
     </ChatHeadlessProvider>
   ),
   args: {
-    title: "My Chatbot"
-  }
+    title: "My Chatbot",
+  },
 };
 
 export const PopupPanel: StoryObj<typeof meta> = {


### PR DESCRIPTION
also add some margin to the first message bubble

J=CLIP-287
TEST=auto&manual

see that send button is disabled when input is empty

<img width="1012" alt="Screenshot 2023-06-26 at 12 14 43 PM" src="https://github.com/yext/chat-ui-react/assets/36055303/d4b34e55-4216-4088-bc1e-850461022e9b">
