### PR TITLE
disable streaming by default in ChatPanel and ChatInput

### DIFF
--- a/docs/chat-ui-react.chatinputprops.md
+++ b/docs/chat-ui-react.chatinputprops.md
@@ -21,5 +21,5 @@ export interface ChatInputProps
 |  [inputAutoFocus?](./chat-ui-react.chatinputprops.inputautofocus.md) |  | boolean | _(Optional)_ Enable auto focus for the input box. Defaults to false. |
 |  [placeholder?](./chat-ui-react.chatinputprops.placeholder.md) |  | string | _(Optional)_ The input's placeholder text when no text has been entered by the user. Defaults to "Type a message...". |
 |  [sendButtonIcon?](./chat-ui-react.chatinputprops.sendbuttonicon.md) |  | JSX.Element | _(Optional)_ Custom icon for the send button. |
-|  [stream?](./chat-ui-react.chatinputprops.stream.md) |  | boolean | _(Optional)_ Enable streaming behavior by making a request to Chat Streaming API. Defaults to true. |
+|  [stream?](./chat-ui-react.chatinputprops.stream.md) |  | boolean | _(Optional)_ Enable streaming behavior by making a request to Chat Streaming API. This feature is experimental, and is subject to change. Defaults to false. |
 

--- a/docs/chat-ui-react.chatinputprops.stream.md
+++ b/docs/chat-ui-react.chatinputprops.stream.md
@@ -4,7 +4,7 @@
 
 ## ChatInputProps.stream property
 
-Enable streaming behavior by making a request to Chat Streaming API. Defaults to true.
+Enable streaming behavior by making a request to Chat Streaming API. This feature is experimental, and is subject to change. Defaults to false.
 
 **Signature:**
 

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -41,7 +41,8 @@ export interface ChatInputProps {
   placeholder?: string;
   /**
    * Enable streaming behavior by making a request to Chat Streaming API.
-   * Defaults to true.
+   * This feature is experimental, and is subject to change.
+   * Defaults to false.
    */
   stream?: boolean;
   /** Enable auto focus for the input box. Defaults to false. */
@@ -70,7 +71,7 @@ export interface ChatInputProps {
  */
 export function ChatInput({
   placeholder = "Type a message...",
-  stream = true,
+  stream = false,
   inputAutoFocus = false,
   handleError,
   sendButtonIcon = <ArrowIcon />,

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -78,7 +78,7 @@ export function ChatPanel(props: ChatPanelProps) {
     if (messages.length !== 0 || !canSendMessage) {
       return;
     }
-    const { stream = true, handleError } = props;
+    const { stream = false, handleError } = props;
     const res = stream ? chat.streamNextMessage() : chat.getNextMessage();
     res.catch((e) => (handleError ? handleError(e) : defaultHandleApiError(e)));
   }, [chat, props, messages, defaultHandleApiError, canSendMessage]);

--- a/tests/components/ChatInput.test.tsx
+++ b/tests/components/ChatInput.test.tsx
@@ -58,7 +58,7 @@ it("sends request and reset input when click on send button", async () => {
   const sendButton = screen.getByRole("button");
   await act(() => userEvent.click(sendButton));
 
-  expect(actions.streamNextMessage).toBeCalledTimes(1);
+  expect(actions.getNextMessage).toBeCalledTimes(1);
   expect(textbox).toHaveDisplayValue("");
 });
 
@@ -69,7 +69,7 @@ it("sends request when hit enter in textarea", async () => {
   const textbox = screen.getByRole("textbox");
   await act(() => userEvent.type(textbox, "test"));
   await act(() => userEvent.keyboard("{Enter}"));
-  expect(actions.streamNextMessage).toBeCalledTimes(1);
+  expect(actions.getNextMessage).toBeCalledTimes(1);
   expect(textbox).toHaveDisplayValue("");
 });
 
@@ -85,7 +85,7 @@ it("does not send request when hit enter in textarea while canSendMessage is fal
   const textbox = screen.getByRole("textbox");
   await act(() => userEvent.type(textbox, "test"));
   await act(() => userEvent.keyboard("{Enter}"));
-  expect(actions.streamNextMessage).toBeCalledTimes(0);
+  expect(actions.getNextMessage).toBeCalledTimes(0);
   expect(textbox).toHaveDisplayValue("test");
 });
 
@@ -96,7 +96,7 @@ it("adds new line hit shift + enter in textarea", async () => {
   const textbox = screen.getByRole("textbox");
   await act(() => userEvent.type(textbox, "test"));
   await act(() => userEvent.keyboard("{Shift>}{Enter}{/Shift}"));
-  expect(actions.streamNextMessage).toBeCalledTimes(0);
+  expect(actions.getNextMessage).toBeCalledTimes(0);
   expect(textbox).toHaveDisplayValue("test\n");
 });
 
@@ -120,8 +120,8 @@ it("disables send button when input is empty", () => {
   expect(screen.getByRole("button")).toBeDisabled();
 });
 
-it("enables stream behavior by default", async () => {
-  render(<ChatInput />);
+it("enables stream behavior when stream prop is true", async () => {
+  render(<ChatInput stream={true} />);
   const actions = spyOnActions();
 
   await act(() => userEvent.type(screen.getByRole("textbox"), "test"));
@@ -131,8 +131,8 @@ it("enables stream behavior by default", async () => {
   expect(actions.getNextMessage).toBeCalledTimes(0);
 });
 
-it("disables stream behavior when stream prop is false", async () => {
-  render(<ChatInput stream={false} />);
+it("disables stream behavior by default", async () => {
+  render(<ChatInput />);
   const actions = spyOnActions();
 
   await act(() => userEvent.type(screen.getByRole("textbox"), "test"));
@@ -149,7 +149,7 @@ it("logs request error and add an error message to state by default", async () =
   });
   const chatActionsSpy = spyOnActions();
   const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
-  render(<ChatInput />);
+  render(<ChatInput stream={true}/>);
   await act(() => userEvent.type(screen.getByRole("textbox"), "test"));
   const sendButton = screen.getByRole("button");
   await act(() => userEvent.click(sendButton));
@@ -165,7 +165,7 @@ it("logs request error and add an error message to state by default", async () =
 
 it("executes custom handleError if provided", async () => {
   mockChatActions({
-    streamNextMessage: jest.fn(() => Promise.reject("API Error")),
+    getNextMessage: jest.fn(() => Promise.reject("API Error")),
   });
   const customHandleError = jest.fn();
   render(<ChatInput handleError={customHandleError} />);

--- a/tests/components/ChatPanel.test.tsx
+++ b/tests/components/ChatPanel.test.tsx
@@ -31,21 +31,21 @@ beforeEach(() => {
 
 it("send request to get initial message on load (stream)", () => {
   const actions = spyOnActions();
-  render(<ChatPanel />);
+  render(<ChatPanel stream={true}/>);
   expect(actions.streamNextMessage).toBeCalledTimes(1);
   expect(actions.streamNextMessage).toBeCalledWith();
 });
 
 it("send request to get initial message on load (non-stream)", () => {
   const actions = spyOnActions();
-  render(<ChatPanel stream={false} />);
+  render(<ChatPanel />);
   expect(actions.getNextMessage).toBeCalledTimes(1);
   expect(actions.getNextMessage).toBeCalledWith();
 });
 
 it("logs request error and add an error message to state by default", async () => {
   mockChatActions({
-    streamNextMessage: jest.fn(() => Promise.reject("API Error")),
+    getNextMessage: jest.fn(() => Promise.reject("API Error")),
     addMessage: jest.fn(),
   });
   const chatActionsSpy = spyOnActions();
@@ -62,7 +62,7 @@ it("logs request error and add an error message to state by default", async () =
 
 it("executes custom handleError if provided", async () => {
   mockChatActions({
-    streamNextMessage: jest.fn(() => Promise.reject("API Error")),
+    getNextMessage: jest.fn(() => Promise.reject("API Error")),
   });
   const customHandleError = jest.fn();
   render(<ChatPanel handleError={customHandleError} />);
@@ -79,7 +79,7 @@ it("doesn't send request to get initial message when there are existing messages
   });
   const actions = spyOnActions();
   render(<ChatPanel />);
-  expect(actions.streamNextMessage).toBeCalledTimes(0);
+  expect(actions.getNextMessage).toBeCalledTimes(0);
 });
 
 it("renders loading dots when loading status is true", () => {


### PR DESCRIPTION
We have decided streaming will be an experimental feature while the bugs are ironed out. This adjusts the components to allow streaming, but not by default.