### PR TITLE
Default full width and height for wrapper class yext-chat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/chat-ui-react",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/chat-ui-react",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-expanding-textarea": "^2.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-ui-react",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A library of React Components for powering Yext Chat integrations.",
   "author": "clippy@yext.com",
   "main": "./lib/commonjs/index.js",

--- a/scoped-bundle.sh
+++ b/scoped-bundle.sh
@@ -6,7 +6,8 @@ npm run tailwindcss -- -o bundle.css --minify -c tailwind.config.js
 # scope styling to class name "yext-chat"
 WRAPPER_CLASSNAME="yext-chat"
 CSS_BUNDLE=$(cat bundle.css)
-echo ".${WRAPPER_CLASSNAME} { ${CSS_BUNDLE} }" > bundle.css
+CUSTOM_CSS="width: 100%; height: 100%;"
+echo ".${WRAPPER_CLASSNAME} { ${CUSTOM_CSS} ${CSS_BUNDLE} }" > bundle.css
 
 # unwrap nesting to follow native css format
 npm run postcss -- bundle.css -o bundle.css

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -23,7 +23,7 @@
     },
     "..": {
       "name": "@yext/chat-ui-react",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-expanding-textarea": "^2.3.6",


### PR DESCRIPTION
Update the css bundle to include width and height to be 100% for `.yext-chat`

TEST=manual

see that bundle is generated successfully and show up in element inspect tab.

<img width="863" alt="Screenshot 2023-07-03 at 1 25 38 PM" src="https://github.com/yext/chat-ui-react/assets/36055303/6d072452-86a7-4f98-be92-83b5f7493dc7">
