### PR TITLE
pass version for clientSdk

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -132,7 +132,7 @@ MIT License
 
 The following npm package may be included in this product:
 
- - @yext/analytics@0.6.0
+ - @yext/analytics@0.6.1
 
 This package contains the following license and notice below:
 
@@ -174,8 +174,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 The following npm packages may be included in this product:
 
  - @yext/chat-core@0.5.3
- - @yext/chat-headless-react@0.5.1
- - @yext/chat-headless@0.5.1
+ - @yext/chat-headless-react@0.5.4
+ - @yext/chat-headless@0.5.4
 
 These packages each contain the following license and notice below:
 

--- a/api-extractor.json
+++ b/api-extractor.json
@@ -45,7 +45,7 @@
    *
    * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
    */
-  "mainEntryPointFilePath": "<projectFolder>/lib/esm/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/lib/esm/src/index.d.ts",
 
   /**
    * A list of NPM package names whose exports should be treated as part of this package.

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "typescript": "^5.0.4"
       },
       "peerDependencies": {
-        "@yext/chat-headless-react": "^0.5.0",
+        "@yext/chat-headless-react": "^0.5.4",
         "react": "^16.14 || ^17 || ^18",
         "react-dom": "^16.14 || ^17 || || ^18"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/chat-ui-react",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/chat-ui-react",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-expanding-textarea": "^2.3.6",
@@ -38,7 +38,7 @@
         "@testing-library/user-event": "^14.4.3",
         "@types/jest": "^29.5.1",
         "@types/react": "^18.2.7",
-        "@yext/chat-headless-react": "^0.5.1",
+        "@yext/chat-headless-react": "^0.5.4",
         "@yext/eslint-config": "^1.0.0",
         "babel-jest": "^29.5.0",
         "eslint": "^8.39.0",
@@ -9666,9 +9666,9 @@
       "dev": true
     },
     "node_modules/@yext/analytics": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@yext/analytics/-/analytics-0.6.0.tgz",
-      "integrity": "sha512-0HIQlBN5d4+IHLYmAFr8eL/yje7+RcP0HuvVFUMnyQybvdyf5qiL3+DTS+IV7BiUFJBkZDmuVeQnTPd5tB9TiA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@yext/analytics/-/analytics-0.6.1.tgz",
+      "integrity": "sha512-Demn/wLWZ8K95R/Klq+DYTpKt/vzNAH4BY1Nkl2lSqrc4ICArxK9feK8NCxSUM+ol15yiL2tBAfXrIpmRZ/pEQ==",
       "dev": true,
       "dependencies": {
         "cross-fetch": "^3.1.5",
@@ -9685,24 +9685,24 @@
       }
     },
     "node_modules/@yext/chat-headless": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@yext/chat-headless/-/chat-headless-0.5.1.tgz",
-      "integrity": "sha512-QUaryYqEpX2n+yyeaMiga7B68Y0+yrqZsNhRXYEkCJY59CZnvWwD4ME/BbrgMBHyuVn2mpFsZ+PxDbpxXGYeYA==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@yext/chat-headless/-/chat-headless-0.5.4.tgz",
+      "integrity": "sha512-8toPwfwbXAST/b1xOwM824NTKdeELHXSB//6tfUX4PJn4uuO/zMTc0JjtvHkbmSezMS08FyaMIezfXW7PFSB1w==",
       "dev": true,
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
-        "@yext/analytics": "^0.6.0",
+        "@yext/analytics": "^0.6.1",
         "@yext/chat-core": "^0.5.3"
       }
     },
     "node_modules/@yext/chat-headless-react": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@yext/chat-headless-react/-/chat-headless-react-0.5.1.tgz",
-      "integrity": "sha512-6dZNfQKB0e64pf5vvUY0/kIfRc4UYHedQFy+k8FpMdEDaXOUvIhX4mZMLAO5AV2BqZ6brPvvKE1sLrb9tldrVw==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@yext/chat-headless-react/-/chat-headless-react-0.5.4.tgz",
+      "integrity": "sha512-mJZnu03oqRM6GfdMPqtBAzm41se8B5nr6fOXUY9kFW1+YJss7CtDrvVtoaWbB7TSU3F4brirNnm266paRBf25A==",
       "dev": true,
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
-        "@yext/chat-headless": "^0.5.1",
+        "@yext/chat-headless": "^0.5.4",
         "react": "^18.2.0",
         "react-redux": "^8.0.5"
       }

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "typescript": "^5.0.4"
   },
   "peerDependencies": {
-    "@yext/chat-headless-react": "^0.5.0",
+    "@yext/chat-headless-react": "^0.5.4",
     "react": "^16.14 || ^17 || ^18",
     "react-dom": "^16.14 || ^17 || || ^18"
   },

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@yext/chat-ui-react",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "A library of React Components for powering Yext Chat integrations.",
   "author": "clippy@yext.com",
-  "main": "./lib/commonjs/index.js",
-  "module": "./lib/esm/index.js",
-  "types": "./lib/esm/index.d.ts",
+  "main": "./lib/commonjs/src/index.js",
+  "module": "./lib/esm/src/index.js",
+  "types": "./lib/esm/src/index.d.ts",
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": "./lib/esm/index.js",
-      "require": "./lib/commonjs/index.js"
+      "import": "./lib/esm/src/index.js",
+      "require": "./lib/commonjs/src/index.js"
     },
     "./bundle.css": "./lib/bundle.css"
   },
@@ -64,7 +64,7 @@
     "@testing-library/user-event": "^14.4.3",
     "@types/jest": "^29.5.1",
     "@types/react": "^18.2.7",
-    "@yext/chat-headless-react": "^0.5.1",
+    "@yext/chat-headless-react": "^0.5.4",
     "@yext/eslint-config": "^1.0.0",
     "babel-jest": "^29.5.0",
     "eslint": "^8.39.0",

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -10,6 +10,7 @@ import { LoadingDots } from "./LoadingDots";
 import { useComposedCssClasses } from "../hooks";
 import { useDefaultHandleApiError } from "../hooks/useDefaultHandleApiError";
 import { withStylelessCssClasses } from "../utils/withStylelessCssClasses";
+import { useReportAnalyticsEvent } from "../hooks/useReportAnalyticsEvent";
 
 /**
  * The CSS class interface for the {@link ChatPanel} component.
@@ -72,12 +73,13 @@ export function ChatPanel(props: ChatPanelProps) {
   );
   const cssClasses = useComposedCssClasses(builtInCssClasses, customCssClasses);
   const defaultHandleApiError = useDefaultHandleApiError();
+  const reportAnalyticsEvent = useReportAnalyticsEvent();
 
   useEffect(() => {
-    chat.report({
+    reportAnalyticsEvent({
       action: "CHAT_IMPRESSION",
     });
-  }, [chat]);
+  }, [reportAnalyticsEvent]);
 
   // Fetch the first message on load, if there are no existing messages or a request being processed
   useEffect(() => {

--- a/src/components/ChatPopUp.tsx
+++ b/src/components/ChatPopUp.tsx
@@ -9,7 +9,7 @@ import {
 import { twMerge } from "tailwind-merge";
 import { useComposedCssClasses } from "../hooks";
 import { withStylelessCssClasses } from "../utils/withStylelessCssClasses";
-import { useChatActions } from "@yext/chat-headless-react";
+import { useReportAnalyticsEvent } from "../hooks/useReportAnalyticsEvent";
 
 /**
  * The CSS class interface for the {@link ChatPopUp} component.
@@ -88,13 +88,13 @@ export function ChatPopUp(props: ChatPopUpProps) {
     onClose: customOnClose,
     title,
   } = props;
+  const reportAnalyticsEvent = useReportAnalyticsEvent();
 
-  const actions = useChatActions();
   useEffect(() => {
-    actions.report({
+    reportAnalyticsEvent({
       action: "CHAT_IMPRESSION",
     });
-  }, [actions]);
+  }, [reportAnalyticsEvent]);
 
   const [showChat, setShowChat] = useState(false);
   const onClick = useCallback(() => {

--- a/src/components/FeedbackButtons.tsx
+++ b/src/components/FeedbackButtons.tsx
@@ -5,7 +5,7 @@ import { ThumbsUpFillIcon } from "../icons/ThumbsUpFill";
 import { ThumbsDownFillIcon } from "../icons/ThumbsDownFill";
 import { withStylelessCssClasses } from "../utils/withStylelessCssClasses";
 import { useComposedCssClasses } from "../hooks";
-import { useChatActions } from "@yext/chat-headless-react";
+import { useReportAnalyticsEvent } from "../hooks/useReportAnalyticsEvent";
 
 /**
  * The CSS class interface for the FeedbackButtons component.
@@ -58,30 +58,30 @@ export function FeedbackButtons({
   customCssClasses,
   responseId,
 }: FeedbackButtonsProps) {
-  const actions = useChatActions();
+  const reportAnalyticsEvent = useReportAnalyticsEvent();
   const cssClasses = useComposedCssClasses(builtInCssClasses, customCssClasses);
   const [selectedThumb, setSelectedThumb] = useState<
     "UP" | "DOWN" | undefined
   >();
   const onClickThumbsUp = useCallback(() => {
     setSelectedThumb("UP");
-    actions.report({
+    reportAnalyticsEvent({
       action: "THUMBS_UP",
       chat: {
         responseId,
       },
     });
-  }, [actions, responseId]);
+  }, [reportAnalyticsEvent, responseId]);
 
   const onClickThumbsDown = useCallback(() => {
     setSelectedThumb("DOWN");
-    actions.report({
+    reportAnalyticsEvent({
       action: "THUMBS_DOWN",
       chat: {
         responseId,
       },
     });
-  }, [actions, responseId]);
+  }, [reportAnalyticsEvent, responseId]);
 
   return (
     <div className={cssClasses.container}>

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -6,7 +6,7 @@ import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize from "rehype-sanitize";
 import { useMemo } from "react";
-import { useChatActions } from "@yext/chat-headless-react";
+import { useReportAnalyticsEvent } from "../hooks/useReportAnalyticsEvent";
 
 // The Remark and Rehype plugins to use in conjunction with ReactMarkdown.
 const unifiedPlugins: { remark?: PluggableList; rehype: PluggableList } = {
@@ -38,10 +38,11 @@ interface MarkdownProps {
  * @internal
  */
 export function Markdown({ content, responseId, className }: MarkdownProps) {
-  const action = useChatActions();
+  const reportAnalyticsEvent = useReportAnalyticsEvent();
+
   const components: ReactMarkdownOptions["components"] = useMemo(() => {
     const createClickHandlerFn = (href?: string) => () => {
-      action.report({
+      reportAnalyticsEvent({
         action: "CHAT_LINK_CLICK",
         destinationUrl: href,
         chat: {
@@ -64,7 +65,7 @@ export function Markdown({ content, responseId, className }: MarkdownProps) {
         );
       },
     };
-  }, [action, responseId]);
+  }, [reportAnalyticsEvent, responseId]);
 
   return (
     <ReactMarkdown

--- a/src/hooks/useReportAnalyticsEvent.ts
+++ b/src/hooks/useReportAnalyticsEvent.ts
@@ -1,0 +1,19 @@
+import { ChatHeadless, useChatActions } from "@yext/chat-headless-react";
+import packageJson from "../../package.json";
+import { useCallback } from "react";
+const { version } = packageJson;
+
+/**
+ * Returns a function to send requests to Yext Analytics API.
+ * The payload will automatically includes chat-ui-react's
+ * package version for "clientSdk" field.
+ *
+ * @internal
+ */
+export function useReportAnalyticsEvent(): ChatHeadless["report"] {
+  const chat = useChatActions();
+  chat.addClientSdk({
+    CHAT_UI_REACT: version,
+  });
+  return useCallback((payload) => chat.report(payload), [chat]);
+}

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -75,7 +75,7 @@
         "typescript": "^5.0.4"
       },
       "peerDependencies": {
-        "@yext/chat-headless-react": "^0.5.0",
+        "@yext/chat-headless-react": "^0.5.4",
         "react": "^16.14 || ^17 || ^18",
         "react-dom": "^16.14 || ^17 || || ^18"
       }

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -23,7 +23,7 @@
     },
     "..": {
       "name": "@yext/chat-ui-react",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-expanding-textarea": "^2.3.6",
@@ -55,7 +55,7 @@
         "@testing-library/user-event": "^14.4.3",
         "@types/jest": "^29.5.1",
         "@types/react": "^18.2.7",
-        "@yext/chat-headless-react": "^0.5.1",
+        "@yext/chat-headless-react": "^0.5.4",
         "@yext/eslint-config": "^1.0.0",
         "babel-jest": "^29.5.0",
         "eslint": "^8.39.0",

--- a/tests/__utils__/mocks.ts
+++ b/tests/__utils__/mocks.ts
@@ -33,7 +33,13 @@ export function mockChatActions(
 ): jest.SpyInstance<typeof useChatActions, unknown[]> {
   return jest
     .spyOn(require("@yext/chat-headless-react"), "useChatActions")
-    .mockImplementation(() => customActions as ChatHeadless);
+    .mockImplementation(
+      () =>
+        ({
+          addClientSdk: jest.fn(), //auto-mock internal function
+          ...customActions,
+        } as ChatHeadless)
+    );
 }
 
 export function mockChatState(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "resolveJsonModule": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
extract chat-ui-react version to pass into `clientSdk` field in analytic event's payload by setting it through the internal function `addClientSdk` in ChatHeadless. This functionality is wrapped in a hook `useReportAnalyticsEvent`.

Due to the import of `package.json` the structure of `dist/` is reformatted (now all previous files are inside src/ and package.json is included in the respective esm and commonjs folder). As such, the entry points needs to be updated to reflect this.

J=CLIP-309
TEST=manual

see in test-site that clientSdk is passed into the payload with the correct versions (e.g. include the new CHAT_UI_REACT in addition to CHAT_HEADLESS_REACT, CHAT_HEADLESS and CHAT_CORE)

<img width="681" alt="Screenshot 2023-07-07 at 3 49 14 PM" src="https://github.com/yext/chat-ui-react/assets/36055303/821fa2d4-ddf5-4feb-9cb9-5b43720a8305">

