### PR TITLE
UI update: remove glass effects, fix long continuous message, change textarea-resize lib

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -444,39 +444,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 The following npm package may be included in this product:
 
- - fast-shallow-equal@1.0.0
-
-This package contains the following license and notice below:
-
-This is free and unencumbered software released into the public domain.
-
-Anyone is free to copy, modify, publish, use, compile, sell, or
-distribute this software, either in source code form or as a compiled
-binary, for any purpose, commercial or non-commercial, and by any
-means.
-
-In jurisdictions that recognize copyright laws, the author or authors
-of this software dedicate any and all copyright interest in the
-software to the public domain. We make this dedication for the benefit
-of the public at large and to the detriment of our heirs and
-successors. We intend this dedication to be an overt act of
-relinquishment in perpetuity of all present and future rights to this
-software under copyright law.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-
-For more information, please refer to <https://unlicense.org>
-
------------
-
-The following npm package may be included in this product:
-
  - hoist-non-react-statics@3.3.2
 
 This package contains the following license and notice below:
@@ -1302,45 +1269,6 @@ SOFTWARE.
 
 The following npm package may be included in this product:
 
- - react-expanding-textarea@2.3.6
-
-This package contains the following license and notice below:
-
-Copyright (c) 2020, Robert Pearce
-
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-
-    * Neither the name of Robert Pearce nor the names of other
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
------------
-
-The following npm package may be included in this product:
-
  - react-markdown@6.0.3
 
 This package contains the following license and notice below:
@@ -1402,7 +1330,7 @@ SOFTWARE.
 
 The following npm package may be included in this product:
 
- - react-textarea-autosize@8.4.1
+ - react-textarea-autosize@8.5.2
 
 This package contains the following license and notice below:
 
@@ -1426,45 +1354,6 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
------------
-
-The following npm package may be included in this product:
-
- - react-with-forwarded-ref@0.3.5
-
-This package contains the following license and notice below:
-
-Copyright (c) 2019, Robert Pearce
-
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-
-    * Neither the name of Robert Pearce nor the names of other
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------
 
@@ -1892,27 +1781,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
------------
-
-The following npm package may be included in this product:
-
- - tslib@2.5.2
-
-This package contains the following license and notice below:
-
-Copyright (c) Microsoft Corporation.
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
-AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
-LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
-OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-PERFORMANCE OF THIS SOFTWARE.
 
 -----------
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,16 @@
 {
   "name": "@yext/chat-ui-react",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/chat-ui-react",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "react-expanding-textarea": "^2.3.6",
         "react-markdown": "^6.0.3",
-        "react-textarea-autosize": "^8.4.1",
+        "react-textarea-autosize": "^8.5.2",
         "rehype-raw": "^5.0.0",
         "rehype-sanitize": "^4.0.0",
         "remark-gfm": "^1.0.0",
@@ -13483,11 +13482,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
-    "node_modules/fast-shallow-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
-      "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
-    },
     "node_modules/fastq": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -20158,24 +20152,6 @@
       "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
       "dev": true
     },
-    "node_modules/react-expanding-textarea": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/react-expanding-textarea/-/react-expanding-textarea-2.3.6.tgz",
-      "integrity": "sha512-LjkyZv1LilMlt+6/yYn9F1FlcK8iQU96myeq6PwU/a7IaQMkSwndSB1SAhMKgxSrUR71VbqsqnAHQ741WbAU/Q==",
-      "dependencies": {
-        "fast-shallow-equal": "^1.0.0",
-        "react-with-forwarded-ref": "^0.3.5",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/react-expanding-textarea/node_modules/tslib": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
-      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
-    },
     "node_modules/react-inspector": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-6.0.1.tgz",
@@ -20273,9 +20249,9 @@
       }
     },
     "node_modules/react-textarea-autosize": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.1.tgz",
-      "integrity": "sha512-aD2C+qK6QypknC+lCMzteOdIjoMbNlgSFmJjCV+DrfTPwp59i/it9mMNf2HDzvRjQgKAyBDPyLJhcrzElf2U4Q==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.2.tgz",
+      "integrity": "sha512-uOkyjkEl0ByEK21eCJMHDGBAAd/BoFQBawYK5XItjAmCTeSbjxghd8qnt7nzsLYzidjnoObu6M26xts0YGKsGg==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "use-composed-ref": "^1.3.0",
@@ -20287,22 +20263,6 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
-    },
-    "node_modules/react-with-forwarded-ref": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/react-with-forwarded-ref/-/react-with-forwarded-ref-0.3.5.tgz",
-      "integrity": "sha512-BJK4q0Nvqg4AFwc+LV+PZZb2nxS1ZqQlS9hY14TdIyg7Lapzirk/V/TtbYjPFSsm/fGm0wC4tsgI1IDhxSVVSQ==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      },
-      "peerDependencies": {
-        "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/react-with-forwarded-ref/node_modules/tslib": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
-      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-ui-react",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "A library of React Components for powering Yext Chat integrations.",
   "author": "clippy@yext.com",
   "main": "./lib/commonjs/src/index.js",
@@ -89,9 +89,8 @@
     "react-dom": "^16.14 || ^17 || || ^18"
   },
   "dependencies": {
-    "react-expanding-textarea": "^2.3.6",
     "react-markdown": "^6.0.3",
-    "react-textarea-autosize": "^8.4.1",
+    "react-textarea-autosize": "^8.5.2",
     "rehype-raw": "^5.0.0",
     "rehype-sanitize": "^4.0.0",
     "remark-gfm": "^1.0.0",

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -2,7 +2,7 @@ import { useCallback, useState } from "react";
 import { useChatActions, useChatState } from "@yext/chat-headless-react";
 import { ArrowIcon } from "../icons/Arrow";
 import { useComposedCssClasses } from "../hooks";
-import TextareaAutosize from 'react-textarea-autosize';
+import TextareaAutosize from "react-textarea-autosize";
 import { useDefaultHandleApiError } from "../hooks/useDefaultHandleApiError";
 import { withStylelessCssClasses } from "../utils/withStylelessCssClasses";
 

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -2,7 +2,7 @@ import { useCallback, useState } from "react";
 import { useChatActions, useChatState } from "@yext/chat-headless-react";
 import { ArrowIcon } from "../icons/Arrow";
 import { useComposedCssClasses } from "../hooks";
-import Textarea from "react-expanding-textarea";
+import TextareaAutosize from 'react-textarea-autosize';
 import { useDefaultHandleApiError } from "../hooks/useDefaultHandleApiError";
 import { withStylelessCssClasses } from "../utils/withStylelessCssClasses";
 
@@ -22,7 +22,7 @@ const builtInCssClasses: ChatInputCssClasses = withStylelessCssClasses(
   {
     container: "w-full h-fit flex flex-row relative @container",
     textArea:
-      "w-full p-4 pr-12 border border-slate-300 rounded-3xl resize-none text-[13px] @[480px]:text-base text-slate-900",
+      "w-full p-4 pr-12 border border-slate-300 rounded-3xl resize-none text-[13px] @[480px]:text-base placeholder:text-[13px] placeholder:@[480px]:text-base text-slate-900",
     sendButton:
       "rounded-full p-1.5 w-8 h-8 stroke-2 text-white bg-blue-600 disabled:bg-slate-200 hover:bg-blue-800 active:scale-90 transition-all absolute right-4 bottom-2.5 @[480px]:bottom-3.5",
   }
@@ -115,7 +115,7 @@ export function ChatInput({
 
   return (
     <div className={cssClasses.container}>
-      <Textarea
+      <TextareaAutosize
         autoFocus={inputAutoFocus}
         onKeyDown={handleKeyDown}
         value={input}

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -31,8 +31,8 @@ const builtInCssClasses: ChatPanelCssClasses = withStylelessCssClasses(
   {
     container: "h-full w-full flex flex-col relative shadow-2xl bg-white",
     messagesScrollContainer: "flex flex-col mt-auto overflow-hidden",
-    messagesContainer: "flex flex-col gap-y-1 px-4 pb-[85px] overflow-auto",
-    inputContainer: "w-full absolute bottom-0 p-4 backdrop-blur-lg",
+    messagesContainer: "flex flex-col gap-y-1 px-4 overflow-auto",
+    inputContainer: "w-full p-4",
     messageBubbleCssClasses: {
       topContainer: "first:mt-4",
     },

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -38,9 +38,9 @@ const builtInCssClasses: MessageBubbleCssClasses =
     bubble__bot: "bg-gradient-to-tr from-slate-50 to-slate-100",
     bubble__user:
       "ml-auto @lg:ml-0 bg-gradient-to-tr from-blue-600 to-blue-700 text-white",
-    text: "text-[13px] @[480px]:text-base prose overflow-x-auto break-words",
+    text: "text-[13px] @[480px]:text-base prose overflow-x-auto",
     text__bot: "text-slate-900",
-    text__user: "text-white",
+    text__user: "text-white break-words",
     timestamp:
       "w-fit my-0.5 ml-4 @lg:ml-0 text-slate-400 text-[10px] @[480px]:text-[13px] opacity-0 peer-hover:opacity-100 duration-200 whitespace-pre-wrap",
     timestamp__bot: "",

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -38,7 +38,7 @@ const builtInCssClasses: MessageBubbleCssClasses =
     bubble__bot: "bg-gradient-to-tr from-slate-50 to-slate-100",
     bubble__user:
       "ml-auto @lg:ml-0 bg-gradient-to-tr from-blue-600 to-blue-700 text-white",
-    text: "text-[13px] @[480px]:text-base prose overflow-x-auto",
+    text: "text-[13px] @[480px]:text-base prose overflow-x-auto break-words",
     text__bot: "text-slate-900",
     text__user: "text-white",
     timestamp:

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -23,12 +23,11 @@
     },
     "..": {
       "name": "@yext/chat-ui-react",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "react-expanding-textarea": "^2.3.6",
         "react-markdown": "^6.0.3",
-        "react-textarea-autosize": "^8.4.1",
+        "react-textarea-autosize": "^8.5.2",
         "rehype-raw": "^5.0.0",
         "rehype-sanitize": "^4.0.0",
         "remark-gfm": "^1.0.0",


### PR DESCRIPTION
as various issues and complexities arise with supporting glass effects ui for the chat panel, we decide to remove it, following the discussion in this [thread](https://yext.slack.com/archives/C04RFPJ3F3P/p1691093817598079).

Also fix the issue with long continuous text message that requites scrolling from user side (this doesn't apply for text from bot side because tables format may require some horizontal scrolling)

Also explicitly add placeholder font size as that doesn't inherit from the element font size but the **root** font-size.

Additionally react-expanding-textarea package that we use to support text-area resizing is not well maintained and its logic seems to present conflict/issues with HH site. I have decided to migrate over to using a newer package react-textarea-autosize, which could help resolve this.

J=CLIP-401,CLIP-405
TEST=manual

https://github.com/yext/chat-ui-react/assets/36055303/c4b97ae9-4834-490d-a1a6-bbad9e3987eb

