### PR TITLE
ChatPanel: Message Scrolling Fix

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -14,7 +14,7 @@ const config: StorybookConfig = {
   },
   docs: {
     autodocs: true,
-    defaultName: "Documentation"
+    defaultName: "Documentation",
   },
   viteFinal: (config, _options) => {
     if (!config.css) {

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -14,8 +14,8 @@ const preview: Preview = {
     docs: {
       story: {
         // https://storybook.js.org/docs/react/api/doc-block-story#autoplay
-        autoplay: true
-      }
+        autoplay: true,
+      },
     },
     actions: { argTypesRegex: "^on[A-Z].*" },
     controls: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-ui-react",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A library of React Components for powering Yext Chat integrations.",
   "author": "clippy@yext.com",
   "main": "./lib/commonjs/src/index.js",

--- a/sites-config/ci_config.json
+++ b/sites-config/ci_config.json
@@ -16,6 +16,6 @@
     "buildCmd": "npm run build-storybook"
   },
   "livePreview": {
-      "serveCmd": "npm run storybook -- -p 8080"
+    "serveCmd": "npm run storybook -- -p 8080"
   }
 }

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useCallback } from "react";
+import React, { useEffect, useRef } from "react";
 import { useChatState, useChatActions } from "@yext/chat-headless-react";
 import {
   MessageBubble,
@@ -120,6 +120,7 @@ export function ChatPanel(props: ChatPanelProps) {
               return (
                 <div
                   key={index}
+                  // eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
                   ref={(message) => (messagesRef.current[index] = message)}
                 >
                   <MessageBubble

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -93,10 +93,11 @@ export function ChatPanel(props: ChatPanelProps) {
   }, [chat, props, messages, defaultHandleApiError, canSendMessage]);
 
   const messagesRef = useRef<HTMLDivElement>(null);
+  const messagesContainer = useRef<HTMLDivElement>(null);
 
   // Scroll to the bottom of the chat when the messages change
   useEffect(() => {
-    messagesRef.current?.scroll({
+    messagesContainer.current?.scroll({
       top: messagesRef.current?.scrollHeight,
       behavior: "smooth",
     });
@@ -107,15 +108,25 @@ export function ChatPanel(props: ChatPanelProps) {
       <div className={cssClasses.container}>
         {header}
         <div className={cssClasses.messagesScrollContainer}>
-          <div ref={messagesRef} className={cssClasses.messagesContainer}>
-            {messages.map((message, index) => (
-              <MessageBubble
-                {...props}
-                customCssClasses={cssClasses.messageBubbleCssClasses}
-                key={index}
-                message={message}
-              />
-            ))}
+          <div ref={messagesContainer} className={cssClasses.messagesContainer}>
+            <div ref={messagesRef}>
+              {messages.slice(0, -1).map((message, index) => {                
+                return <MessageBubble
+                    {...props}
+                    customCssClasses={cssClasses.messageBubbleCssClasses}
+                    key={index}
+                    message={message}
+                  />
+             })}
+            </div>
+              {messages.length > 0 ? 
+                <MessageBubble
+                    {...props}
+                    customCssClasses={cssClasses.messageBubbleCssClasses}
+                    key={messages.length - 1}
+                    message={messages[messages.length-1]}
+                  /> : null
+              }
             {loading && <LoadingDots />}
           </div>
         </div>

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef} from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import { useChatState, useChatActions } from "@yext/chat-headless-react";
 import {
   MessageBubble,
@@ -103,9 +103,9 @@ export function ChatPanel(props: ChatPanelProps) {
     // Sums up scroll heights of all messages except the last one
     if (messagesRef?.current.length > 1) {
       scrollTop = messagesRef.current
-      .slice(0, -1)
-      .map((elem, _) => elem?.scrollHeight ?? 0)
-      .reduce((total, height) => total + height);
+        .slice(0, -1)
+        .map((elem, _) => elem?.scrollHeight ?? 0)
+        .reduce((total, height) => total + height);
     }
 
     // Scroll to the top of the last message
@@ -117,27 +117,27 @@ export function ChatPanel(props: ChatPanelProps) {
 
   const setMessagesRef = useCallback((index) => {
     if (!messagesRef?.current) return null;
-    return (message) => messagesRef.current[index] = message
-  }, [])
+    return (message) => (messagesRef.current[index] = message);
+  }, []);
 
   return (
     <div className="yext-chat w-full h-full">
       <div className={cssClasses.container}>
         {header}
         <div className={cssClasses.messagesScrollContainer}>
-          <div aria-label="test" ref={messagesContainer} className={cssClasses.messagesContainer}>
-            {messages.map((message, index) => 
-                <div
-                  key={index}
-                  ref={setMessagesRef(index)}
-                >
-                  <MessageBubble
-                    {...props}
-                    customCssClasses={cssClasses.messageBubbleCssClasses}
-                    message={message}
-                  />
-                </div>
-            )}
+          <div
+            ref={messagesContainer}
+            className={cssClasses.messagesContainer}
+          >
+            {messages.map((message, index) => (
+              <div key={index} ref={setMessagesRef(index)}>
+                <MessageBubble
+                  {...props}
+                  customCssClasses={cssClasses.messageBubbleCssClasses}
+                  message={message}
+                />
+              </div>
+            ))}
             {loading && <LoadingDots />}
           </div>
         </div>

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useRef} from "react";
 import { useChatState, useChatActions } from "@yext/chat-headless-react";
 import {
   MessageBubble,
@@ -95,33 +95,41 @@ export function ChatPanel(props: ChatPanelProps) {
   const messagesRef = useRef<Array<HTMLDivElement | null>>([]);
   const messagesContainer = useRef<HTMLDivElement>(null);
 
-  // Scroll to the bottom of the chat when the messages change
+  // Handle scrolling when messages change
   useEffect(() => {
-    if (messagesRef?.current.length < 2) {
-      return;
-    }
-    const scrollTop = messagesRef.current
+    let scrollTop = 0;
+    messagesRef.current = messagesRef.current.slice(0, messages.length);
+
+    // Sums up scroll heights of all messages except the last one
+    if (messagesRef?.current.length > 1) {
+      scrollTop = messagesRef.current
       .slice(0, -1)
       .map((elem, _) => elem?.scrollHeight ?? 0)
       .reduce((total, height) => total + height);
+    }
+
+    // Scroll to the top of the last message
     messagesContainer.current?.scroll({
       top: scrollTop,
       behavior: "smooth",
     });
   }, [messages]);
 
+  const setMessagesRef = useCallback((index) => {
+    if (!messagesRef?.current) return null;
+    return (message) => messagesRef.current[index] = message
+  }, [])
+
   return (
     <div className="yext-chat w-full h-full">
       <div className={cssClasses.container}>
         {header}
         <div className={cssClasses.messagesScrollContainer}>
-          <div ref={messagesContainer} className={cssClasses.messagesContainer}>
-            {messages.map((message, index) => {
-              return (
+          <div aria-label="test" ref={messagesContainer} className={cssClasses.messagesContainer}>
+            {messages.map((message, index) => 
                 <div
                   key={index}
-                  // eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
-                  ref={(message) => (messagesRef.current[index] = message)}
+                  ref={setMessagesRef(index)}
                 >
                   <MessageBubble
                     {...props}
@@ -129,8 +137,7 @@ export function ChatPanel(props: ChatPanelProps) {
                     message={message}
                   />
                 </div>
-              );
-            })}
+            )}
             {loading && <LoadingDots />}
           </div>
         </div>

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -23,7 +23,7 @@
     },
     "..": {
       "name": "@yext/chat-ui-react",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-markdown": "^6.0.3",

--- a/test-site/src/App.tsx
+++ b/test-site/src/App.tsx
@@ -20,21 +20,21 @@ function App() {
   return (
     <div>
       <div className="h-screen w-screen flex justify-center items-center bg-red-400">
-      {/* <h1 className="external-element">External Element!</h1> */}
+        {/* <h1 className="external-element">External Element!</h1> */}
+        <ChatHeadlessProvider config={config}>
+          <div className="h-5/6 w-1/2">
+            <ChatPanel
+              header={
+                <ChatHeader title="Clippy's Chatbot" showRestartButton={true} />
+              }
+            />
+          </div>
+        </ChatHeadlessProvider>
+      </div>
       <ChatHeadlessProvider config={config}>
-        <div className="h-5/6 w-1/2">
-          <ChatPanel
-            header={
-              <ChatHeader title="Clippy's Chatbot" showRestartButton={true} />
-            }
-          />
-        </div>
+        <ChatPopUp title="Clippy" />
       </ChatHeadlessProvider>
     </div>
-    <ChatHeadlessProvider config={config}>
-      <ChatPopUp title="Clippy" />
-    </ChatHeadlessProvider>
-  </div>
   );
 }
 

--- a/tests/__utils__/stories.tsx
+++ b/tests/__utils__/stories.tsx
@@ -1,4 +1,7 @@
-import { ChatHeadlessProvider, HeadlessConfig } from "@yext/chat-headless-react";
+import {
+  ChatHeadlessProvider,
+  HeadlessConfig,
+} from "@yext/chat-headless-react";
 
 const config: HeadlessConfig = {
   botId: "DUMMY_BOT_ID",
@@ -6,7 +9,7 @@ const config: HeadlessConfig = {
 };
 
 export function DummyChatHeadlessProvider({ children }) {
-  return <ChatHeadlessProvider config={config}>
-    {children}
-  </ChatHeadlessProvider>
+  return (
+    <ChatHeadlessProvider config={config}>{children}</ChatHeadlessProvider>
+  );
 }

--- a/tests/components/ChatPanel.test.tsx
+++ b/tests/components/ChatPanel.test.tsx
@@ -1,4 +1,8 @@
-import { render, screen, waitFor } from "@testing-library/react";
+// issue with testing library + React 18: https://github.com/testing-library/react-testing-library/issues/1216
+/* eslint-disable testing-library/no-unnecessary-act */
+
+import { render, screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { ChatPanel } from "../../src";
 import {
   mockChatActions,
@@ -13,6 +17,12 @@ const dummyMessage: Message = {
   source: "BOT",
   text: "Hello! This is Yext Chat!",
 };
+
+const veryLongMessage = `this is a very long message, this is a very long message, this is a very long message, this is a very long message, this is a very long message
+, this is a very long message, this is a very long message, this is a very long message, this is a very long message, this is a very long message this is a very long message, this is a very long message, 
+, this is a very long message, this is a very long message, this is a very long message, this is a very long message, this is a very long message, this is a very long message, this is a very long message, this is a very long message
+, this is a very long message, this is a very long message, this is a very long message, this is a very long message, this is a very long message, this is a very long message, this is a very long message
+, this is a very long message, this is a very long message, this is a very long message, this is a very long message, this is a very long message, this is a very long message, this is a very long message`
 
 jest.mock("@yext/analytics");
 
@@ -122,3 +132,18 @@ it("display message bubbles based on messages in state", () => {
   render(<ChatPanel />);
   expect(screen.getByText(dummyMessage.text)).toBeInTheDocument();
 });
+
+it("scrolls when a new message is added", async () => {
+  mockChatState({
+    conversation: {
+      messages: [dummyMessage],
+      isLoading: false,
+      canSendMessage: true,
+    },
+  });
+  render(<ChatPanel />);
+  await act(() => userEvent.type(screen.getByRole("textbox"), veryLongMessage));
+  await act(() => userEvent.keyboard("{Enter}"));
+  expect(screen.queryByLabelText("Messages Container")?.clientHeight).toBe(2);
+});
+

--- a/tests/components/ChatPanel.test.tsx
+++ b/tests/components/ChatPanel.test.tsx
@@ -7,7 +7,6 @@ import {
   spyOnActions,
 } from "../__utils__/mocks";
 import { Message, MessageSource } from "@yext/chat-headless-react";
-import React from "react";
 
 const dummyMessage: Message = {
   timestamp: "2023-05-31T14:22:19.376Z",

--- a/tests/components/ChatPanel.test.tsx
+++ b/tests/components/ChatPanel.test.tsx
@@ -1,8 +1,6 @@
 // issue with testing library + React 18: https://github.com/testing-library/react-testing-library/issues/1216
 /* eslint-disable testing-library/no-unnecessary-act */
-
-import { render, screen, waitFor, act } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { render, screen, waitFor } from "@testing-library/react";
 import { ChatPanel } from "../../src";
 import {
   mockChatActions,
@@ -11,18 +9,13 @@ import {
   spyOnActions,
 } from "../__utils__/mocks";
 import { Message, MessageSource } from "@yext/chat-headless-react";
+import React from "react";
 
 const dummyMessage: Message = {
   timestamp: "2023-05-31T14:22:19.376Z",
   source: "BOT",
   text: "Hello! This is Yext Chat!",
 };
-
-const veryLongMessage = `this is a very long message, this is a very long message, this is a very long message, this is a very long message, this is a very long message
-, this is a very long message, this is a very long message, this is a very long message, this is a very long message, this is a very long message this is a very long message, this is a very long message, 
-, this is a very long message, this is a very long message, this is a very long message, this is a very long message, this is a very long message, this is a very long message, this is a very long message, this is a very long message
-, this is a very long message, this is a very long message, this is a very long message, this is a very long message, this is a very long message, this is a very long message, this is a very long message
-, this is a very long message, this is a very long message, this is a very long message, this is a very long message, this is a very long message, this is a very long message, this is a very long message`
 
 jest.mock("@yext/analytics");
 
@@ -132,18 +125,3 @@ it("display message bubbles based on messages in state", () => {
   render(<ChatPanel />);
   expect(screen.getByText(dummyMessage.text)).toBeInTheDocument();
 });
-
-it("scrolls when a new message is added", async () => {
-  mockChatState({
-    conversation: {
-      messages: [dummyMessage],
-      isLoading: false,
-      canSendMessage: true,
-    },
-  });
-  render(<ChatPanel />);
-  await act(() => userEvent.type(screen.getByRole("textbox"), veryLongMessage));
-  await act(() => userEvent.keyboard("{Enter}"));
-  expect(screen.queryByLabelText("Messages Container")?.clientHeight).toBe(2);
-});
-

--- a/tests/components/ChatPanel.test.tsx
+++ b/tests/components/ChatPanel.test.tsx
@@ -1,5 +1,3 @@
-// issue with testing library + React 18: https://github.com/testing-library/react-testing-library/issues/1216
-/* eslint-disable testing-library/no-unnecessary-act */
 import { render, screen, waitFor } from "@testing-library/react";
 import { ChatPanel } from "../../src";
 import {

--- a/tests/components/ChatPopUp.stories.tsx
+++ b/tests/components/ChatPopUp.stories.tsx
@@ -15,8 +15,8 @@ export default meta;
  * https://github.com/storybookjs/storybook/issues/16774
  */
 const styles = {
-  transform: 'scale(1)',
-  height: '80vh',
+  transform: "scale(1)",
+  height: "80vh",
 };
 
 export const PopupButton: StoryObj<typeof meta> = {

--- a/tests/components/MessageBubble.stories.tsx
+++ b/tests/components/MessageBubble.stories.tsx
@@ -10,9 +10,11 @@ const meta: Meta<typeof MessageBubble> = {
 export default meta;
 
 const Base: StoryObj<typeof meta> = {
-  render: (args) => <DummyChatHeadlessProvider>
-    <MessageBubble {...args} />
-  </DummyChatHeadlessProvider>,
+  render: (args) => (
+    <DummyChatHeadlessProvider>
+      <MessageBubble {...args} />
+    </DummyChatHeadlessProvider>
+  ),
 };
 
 export const BotMessage: StoryObj<typeof meta> = {


### PR DESCRIPTION
ensures that the chat panel scrolls to the top
of a new message, not the bottom. This is relevant for messages that are longer than the chat panel
height.

J=CLIP-580
TEST=manual

ran locally and verified functionality
(skip to 35 seconds to see long message, most of video shows unchanged functionality)

https://github.com/yext/chat-ui-react/assets/18685532/726ed70d-a7e9-4369-841a-1420db1c0b4a 


Change-Id: Ie0537282c91a9762d3cfcdba1d4a7988a61cf5be