### PR TITLE
Feature Proposal - Add option for a footer in the chat panel

### DIFF
--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from "react";
+import ReactMarkdown from "react-markdown";
 import { useChatState, useChatActions } from "@yext/chat-headless-react";
 import {
   MessageBubble,
@@ -50,6 +51,10 @@ export interface ChatPanelProps
   /** A header to render at the top of the panel. */
   header?: JSX.Element;
   /**
+   * A footer to render at the bottom of the panel
+   */
+  footerText?: string;
+  /**
    * CSS classes for customizing the component styling.
    */
   customCssClasses?: ChatPanelCssClasses;
@@ -65,7 +70,7 @@ export interface ChatPanelProps
  * @param props - {@link ChatPanelProps}
  */
 export function ChatPanel(props: ChatPanelProps) {
-  const { header, customCssClasses } = props;
+  const { header, customCssClasses, footerText } = props;
   const chat = useChatActions();
   const messages = useChatState((state) => state.conversation.messages);
   const loading = useChatState((state) => state.conversation.isLoading);
@@ -122,6 +127,11 @@ export function ChatPanel(props: ChatPanelProps) {
         <div className={cssClasses.inputContainer}>
           <ChatInput {...props} customCssClasses={cssClasses.inputCssClasses} />
         </div>
+        {footerText && (
+          <div className="yext-chat__footer text-center text-slate-400 rounded-b-3xl px-4 pb-4 text-[12px]">
+            <ReactMarkdown children={footerText} />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/ChatPopUp.tsx
+++ b/src/components/ChatPopUp.tsx
@@ -71,6 +71,10 @@ export interface ChatPopUpProps
    * CSS classes for customizing the component styling.
    */
   customCssClasses?: ChatPopUpCssClasses;
+  /**
+   * A footer to render at the bottom of the panel
+   */
+  footerText?: string;
 }
 
 /**
@@ -88,6 +92,7 @@ export function ChatPopUp(props: ChatPopUpProps) {
     showRestartButton = true,
     onClose: customOnClose,
     title,
+    footerText,
   } = props;
   const reportAnalyticsEvent = useReportAnalyticsEvent();
 
@@ -133,6 +138,7 @@ export function ChatPopUp(props: ChatPopUpProps) {
                 customCssClasses={cssClasses.headerCssClasses}
               />
             }
+            footerText={footerText}
           />
         </div>
         <button

--- a/tests/components/ChatPanel.stories.tsx
+++ b/tests/components/ChatPanel.stories.tsx
@@ -28,3 +28,13 @@ export const PanelWithHeader: StoryObj<typeof meta> = {
     stream: false,
   },
 };
+
+export const PanelWithFooter: StoryObj<typeof meta> = {
+  ...Primary,
+  args: {
+    header: <ChatHeader title="My Chatbot" showRestartButton={true} />,
+    footerText:
+      "Yext and its affiliates will process your personal data as described in [Yext's Privacy Policy](https://www.yext.com/privacy-policy).",
+    stream: false,
+  },
+};

--- a/tests/components/ChatPopUp.stories.tsx
+++ b/tests/components/ChatPopUp.stories.tsx
@@ -15,8 +15,8 @@ export default meta;
  * https://github.com/storybookjs/storybook/issues/16774
  */
 const styles = {
-  transform: 'scale(1)',
-  height: '80vh',
+  transform: "scale(1)",
+  height: "80vh",
 };
 
 export const PopupButton: StoryObj<typeof meta> = {
@@ -37,5 +37,17 @@ export const PopupPanel: StoryObj<typeof meta> = {
   play: ({ canvasElement }) => {
     const canvas = within(canvasElement);
     userEvent.click(canvas.getByLabelText("Chat Popup Button"));
+  },
+};
+
+export const PopupPanelWithFooter: StoryObj<typeof meta> = {
+  ...PopupButton,
+  play: ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    userEvent.click(canvas.getByLabelText("Chat Popup Button"));
+  },
+  args: {
+    footerText:
+      "Yext and its affiliates will process your personal data as described in [Yext's Privacy Policy](https://www.yext.com/privacy-policy).",
   },
 };


### PR DESCRIPTION
I wanted to propose a small feature - adding an option for a footer text in the `ChatPanel`.
This would be helpful for displaying a link to the Privacy Policy for example. 

![Screenshot 2023-09-21 at 11 15 45](https://github.com/yext/chat-ui-react/assets/22330133/cb2ed5e8-686f-4541-b5e8-e7441e218209)
