### PR TITLE
fix duplicate error messages

### DIFF
--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useChatState, useChatActions } from "@yext/chat-headless-react";
 import {
   MessageBubble,
@@ -65,7 +65,7 @@ export interface ChatPanelProps
  * @param props - {@link ChatPanelProps}
  */
 export function ChatPanel(props: ChatPanelProps) {
-  const { header, customCssClasses } = props;
+  const { header, customCssClasses, stream, handleError } = props;
   const chat = useChatActions();
   const messages = useChatState((state) => state.conversation.messages);
   const loading = useChatState((state) => state.conversation.isLoading);
@@ -75,6 +75,7 @@ export function ChatPanel(props: ChatPanelProps) {
   const cssClasses = useComposedCssClasses(builtInCssClasses, customCssClasses);
   const defaultHandleApiError = useDefaultHandleApiError();
   const reportAnalyticsEvent = useReportAnalyticsEvent();
+  const [fetchInitialMessage, setFetchInitialMessage] = useState(false);
 
   useEffect(() => {
     reportAnalyticsEvent({
@@ -82,15 +83,20 @@ export function ChatPanel(props: ChatPanelProps) {
     });
   }, [reportAnalyticsEvent]);
 
-  // Fetch the first message on load, if there are no existing messages or a request being processed
+  // Request initial message only if there are no existing messages and no ongoing request.
   useEffect(() => {
-    if (messages.length !== 0 || !canSendMessage) {
+    setFetchInitialMessage(messages.length === 0 && canSendMessage)
+  }, [messages.length, canSendMessage])
+
+  useEffect(() => {
+    if (!fetchInitialMessage) {
       return;
     }
-    const { stream = false, handleError } = props;
+  // Ensures that the fetch for the initial message occurs only once
+    setFetchInitialMessage(false)
     const res = stream ? chat.streamNextMessage() : chat.getNextMessage();
     res.catch((e) => (handleError ? handleError(e) : defaultHandleApiError(e)));
-  }, [chat, props, messages, defaultHandleApiError, canSendMessage]);
+  }, [chat, stream, handleError, defaultHandleApiError, fetchInitialMessage]);
 
   const messagesRef = useRef<Array<HTMLDivElement | null>>([]);
   const messagesContainer = useRef<HTMLDivElement>(null);

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -85,15 +85,15 @@ export function ChatPanel(props: ChatPanelProps) {
 
   // Request initial message only if there are no existing messages and no ongoing request.
   useEffect(() => {
-    setFetchInitialMessage(messages.length === 0 && canSendMessage)
-  }, [messages.length, canSendMessage])
+    setFetchInitialMessage(messages.length === 0 && canSendMessage);
+  }, [messages.length, canSendMessage]);
 
   useEffect(() => {
     if (!fetchInitialMessage) {
       return;
     }
-  // Ensures that the fetch for the initial message occurs only once
-    setFetchInitialMessage(false)
+    // Ensures that the fetch for the initial message occurs only once
+    setFetchInitialMessage(false);
     const res = stream ? chat.streamNextMessage() : chat.getNextMessage();
     res.catch((e) => (handleError ? handleError(e) : defaultHandleApiError(e)));
   }, [chat, stream, handleError, defaultHandleApiError, fetchInitialMessage]);
@@ -131,10 +131,7 @@ export function ChatPanel(props: ChatPanelProps) {
       <div className={cssClasses.container}>
         {header}
         <div className={cssClasses.messagesScrollContainer}>
-          <div
-            ref={messagesContainer}
-            className={cssClasses.messagesContainer}
-          >
+          <div ref={messagesContainer} className={cssClasses.messagesContainer}>
             {messages.map((message, index) => (
               <div key={index} ref={setMessagesRef(index)}>
                 <MessageBubble


### PR DESCRIPTION
Previously, ChatPanel produces double-sending error message on initial failure. **This is because React state updates in async/catch operation will NOT be batched.**
As such, state updates from `getNextMessage` function will trigger a re-render first (aka `setCanSendMessage=true and setChatLoadingStatus=false` with no new messages). This would bypass the check below and **send another request for the initial message**
![Screenshot 2023-10-17 at 2 32 08 PM](https://github.com/yext/chat-ui-react/assets/36055303/40cfce7b-06e4-4e10-ab3f-5301f97b148d)
then changes from the first request's `catch` clause get executed, which adds a default error message to state -- stopping this loop. The second request then also error out and run the catch clause, adding a second error message.

Solution:
separate out the check above to its own `fetchInitialMessage` state and manually set that state to false when the useEffect containing the actual fetch request is called. 

J=CLIP-681
TEST=manual

see that only one error message appear on failure. Behavior is as expected on refresh and non-failure state as well.

![Screenshot 2023-10-17 at 2 39 00 PM](https://github.com/yext/chat-ui-react/assets/36055303/6dc597f8-bc10-4138-b2c2-661ba71ec52a)
