### PR TITLE
ChatPopUp: support initial message pop up

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,14 @@ module.exports = {
     "@yext/eslint-config/typescript-react",
     "plugin:storybook/recommended",
   ],
-  ignorePatterns: ["**/lib", "**/dist", "**/build", "**/coverage", "*.d.ts"],
+  ignorePatterns: [
+    "**/lib",
+    "**/dist",
+    "**/build",
+    "**/coverage",
+    "*.d.ts",
+    "**/storybook-static",
+  ],
   overrides: [
     {
       files: ["**/*.{test,stories}.*"],

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,7 @@
 **/docs
 **/dist
 **/etc
+**/storybook-static
 .github
 package*.json
 *.d.ts

--- a/src/components/ChatPopUp.tsx
+++ b/src/components/ChatPopUp.tsx
@@ -10,6 +10,10 @@ import { twMerge } from "tailwind-merge";
 import { useComposedCssClasses } from "../hooks";
 import { withStylelessCssClasses } from "../utils/withStylelessCssClasses";
 import { useReportAnalyticsEvent } from "../hooks/useReportAnalyticsEvent";
+import {
+  InitialMessagePopUp,
+  InitialMessagePopUpCssClasses,
+} from "./InitialMessagePopUp";
 
 /**
  * The CSS class interface for the {@link ChatPopUp} component.
@@ -22,11 +26,13 @@ export interface ChatPopUpCssClasses {
   panel__display?: string;
   panel__hidden?: string;
   button?: string;
-  button__display?: string;
-  button__hidden?: string;
   buttonIcon?: string;
+  closedPopupContainer?: string;
+  closedPopupContainer__display?: string;
+  closedPopupContainer__hidden?: string;
   headerCssClasses?: ChatHeaderCssClasses;
   panelCssClasses?: ChatPanelCssClasses;
+  initialMessagePopUpCssClasses?: InitialMessagePopUpCssClasses;
 }
 
 const fixedPosition = "fixed bottom-6 right-4 lg:bottom-14 lg:right-10 z-50 ";
@@ -39,12 +45,12 @@ const builtInCssClasses: ChatPopUpCssClasses = withStylelessCssClasses(
       "w-80 max-[480px]:right-0 max-[480px]:bottom-0 max-[480px]:w-full max-[480px]:h-full lg:w-96 h-[75vh]",
     panel__display: "duration-300 translate-y-0",
     panel__hidden: "duration-300 translate-y-[20%] opacity-0 invisible",
-    button:
-      fixedPosition +
-      "p-2 w-12 h-12 lg:w-16 lg:h-16 flex justify-center items-center text-white shadow-xl rounded-full bg-gradient-to-br from-blue-600 to-blue-700 hover:-translate-y-2 duration-150",
-    button__display: "duration-300 transform translate-y-0",
-    button__hidden:
+    closedPopupContainer: fixedPosition + "flex gap-x-2.5",
+    closedPopupContainer__display: "duration-300 transform translate-y-0",
+    closedPopupContainer__hidden:
       "duration-300 transform translate-y-[20%] opacity-0 invisible",
+    button:
+      "p-2 w-12 h-12 lg:w-16 lg:h-16 flex justify-center items-center text-white shadow-xl rounded-full bg-gradient-to-br from-blue-600 to-blue-700 hover:-translate-y-2 duration-150",
     buttonIcon: "text-blue-600 w-[28px] h-[28px] lg:w-[40px] lg:h-[40px]",
     headerCssClasses: {
       container: "max-[480px]:rounded-none rounded-t-3xl",
@@ -67,12 +73,12 @@ export interface ChatPopUpProps
     Omit<ChatPanelProps, "header" | "customCssClasses"> {
   /** Custom icon for the popup button to open the panel. */
   openPanelButtonIcon?: JSX.Element;
-  /**
-   * CSS classes for customizing the component styling.
-   */
+  /** CSS classes for customizing the component styling. */
   customCssClasses?: ChatPopUpCssClasses;
   /** Whether to show the panel on load. Defaults to false. */
   openOnLoad?: boolean;
+  /** Whether to show the initial message popup when the panel is hidden. Defaults to false. */
+  showInitialMessagePopUp?: boolean;
 }
 
 /**
@@ -90,6 +96,7 @@ export function ChatPopUp(props: ChatPopUpProps) {
     showRestartButton = true,
     onClose: customOnClose,
     openOnLoad = false,
+    showInitialMessagePopUp = false,
     title,
   } = props;
   const reportAnalyticsEvent = useReportAnalyticsEvent();
@@ -99,6 +106,13 @@ export function ChatPopUp(props: ChatPopUpProps) {
       action: "CHAT_IMPRESSION",
     });
   }, [reportAnalyticsEvent]);
+
+  const [showInitialMessage, setshowInitialMessage] = useState(
+    showInitialMessagePopUp
+  );
+  const onCloseInitialMessage = useCallback(() => {
+    setshowInitialMessage(false);
+  }, []);
 
   // control CSS behavior on open/close state of the panel
   const [showChat, setShowChat] = useState(false);
@@ -110,13 +124,17 @@ export function ChatPopUp(props: ChatPopUpProps) {
   // update in useEffect, instead of having openOnLoad as initial state for show/renderChat,
   // in order to maintain the fade-in CSS animation when opening the panel on load
   useEffect(() => {
-    setShowChat(openOnLoad);
-    setRenderChat(openOnLoad);
+    if (openOnLoad) {
+      setShowChat(true);
+      setRenderChat(true);
+      setshowInitialMessage(false);
+    }
   }, [openOnLoad]);
 
   const onClick = useCallback(() => {
     setShowChat(!showChat);
     setRenderChat(true);
+    setshowInitialMessage(false);
   }, [showChat]);
 
   const onClose = useCallback(() => {
@@ -129,9 +147,11 @@ export function ChatPopUp(props: ChatPopUpProps) {
     cssClasses.panel,
     showChat ? cssClasses.panel__display : cssClasses.panel__hidden
   );
-  const buttonCssClasses = twMerge(
-    cssClasses.button,
-    showChat ? cssClasses.button__hidden : cssClasses.button__display
+  const closedPopupContainerCssClasses = twMerge(
+    cssClasses.closedPopupContainer,
+    showChat
+      ? cssClasses.closedPopupContainer__hidden
+      : cssClasses.closedPopupContainer__display
   );
 
   return (
@@ -154,15 +174,26 @@ export function ChatPopUp(props: ChatPopUpProps) {
             />
           )}
         </div>
-        <button
-          aria-label="Chat Popup Button"
-          onClick={onClick}
-          className={buttonCssClasses}
+        <div
+          className={closedPopupContainerCssClasses}
+          aria-label="Chat Closed Popup Container"
         >
-          {openPanelButtonIcon ?? (
-            <ChatIcon className={cssClasses.buttonIcon} />
+          {showInitialMessage && (
+            <InitialMessagePopUp
+              onClose={onCloseInitialMessage}
+              customCssClasses={cssClasses.initialMessagePopUpCssClasses}
+            />
           )}
-        </button>
+          <button
+            aria-label="Chat Popup Button"
+            onClick={onClick}
+            className={cssClasses.button}
+          >
+            {openPanelButtonIcon ?? (
+              <ChatIcon className={cssClasses.buttonIcon} />
+            )}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/InitialMessagePopUp.tsx
+++ b/src/components/InitialMessagePopUp.tsx
@@ -1,0 +1,78 @@
+import React, { useMemo } from "react";
+import { CrossIcon } from "../icons/Cross";
+import { useComposedCssClasses } from "../hooks";
+import { withStylelessCssClasses } from "../utils/withStylelessCssClasses";
+import { MessageSource, useChatState } from "@yext/chat-headless-react";
+import { useFetchInitialMessage } from "../hooks/useFetchInitialMessage";
+
+/**
+ * The CSS class interface for the {@link InitialMessagePopUp} component.
+ *
+ * @public
+ */
+export interface InitialMessagePopUpCssClasses {
+  container?: string;
+  closeButton?: string;
+  closeButtonIcon?: string;
+  message?: string;
+}
+
+/**
+ * The props for the {@link InitialMessagePopUp} component.
+ *
+ * @internal
+ */
+interface InitialMessagePopUpProps {
+  /** CSS classes for customizing the component styling. */
+  customCssClasses?: InitialMessagePopUpCssClasses;
+  /** Function to call when user click on the close button */
+  onClose: () => void;
+}
+
+const builtInCssClasses: InitialMessagePopUpCssClasses =
+  withStylelessCssClasses("InitialMessagePopUp", {
+    container: "flex gap-x-1",
+    closeButton: "bg-white w-4 h-4 rounded-full border border-slate-300",
+    closeButtonIcon: "",
+    message:
+      "line-clamp-2 w-60 h-12 lg:h-16 p-2.5 bg-white rounded-xl shadow-xl text-sm",
+  });
+
+/**
+ * A component that renders a popup bubble displaying the initial message from chat bot.
+ *
+ * @internal
+ *
+ * @param props - {@link InitialMessagePopUpProps}
+ */
+export function InitialMessagePopUp({
+  onClose,
+  customCssClasses,
+}: InitialMessagePopUpProps) {
+  const messages = useChatState((s) => s.conversation.messages);
+  const cssClasses = useComposedCssClasses(builtInCssClasses, customCssClasses);
+
+  useFetchInitialMessage((e: unknown) => console.error(e));
+  const firstBotMessage: string = useMemo(() => {
+    return messages.length !== 0 && messages[0].source === MessageSource.BOT
+      ? messages[0].text
+      : "";
+  }, [messages]);
+
+  if (firstBotMessage.length === 0) {
+    return <></>;
+  }
+
+  return (
+    <div className={cssClasses.container}>
+      <button
+        aria-label="Close Initial Message"
+        onClick={onClose}
+        className={cssClasses.closeButton}
+      >
+        <CrossIcon className={cssClasses.closeButtonIcon} />
+      </button>
+      <div className={cssClasses.message}>{firstBotMessage}</div>
+    </div>
+  );
+}

--- a/src/components/InitialMessagePopUp.tsx
+++ b/src/components/InitialMessagePopUp.tsx
@@ -31,7 +31,7 @@ interface InitialMessagePopUpProps {
 
 const builtInCssClasses: InitialMessagePopUpCssClasses =
   withStylelessCssClasses("InitialMessagePopUp", {
-    container: "flex gap-x-1",
+    container: "flex gap-x-1 animate-fade-in",
     closeButton: "bg-white w-4 h-4 rounded-full border border-slate-300",
     closeButtonIcon: "",
     message:

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -10,10 +10,11 @@ export type {
   MessageBubbleProps,
 } from "./MessageBubble";
 
-export type { FeedbackButtonsCssClasses } from "./FeedbackButtons";
-
 export { ChatPanel } from "./ChatPanel";
 export type { ChatPanelCssClasses, ChatPanelProps } from "./ChatPanel";
 
 export { ChatPopUp } from "./ChatPopUp";
 export type { ChatPopUpCssClasses, ChatPopUpProps } from "./ChatPopUp";
+
+export type { FeedbackButtonsCssClasses } from "./FeedbackButtons";
+export type { InitialMessagePopUpCssClasses } from "./InitialMessagePopUp";

--- a/src/hooks/useFetchInitialMessage.ts
+++ b/src/hooks/useFetchInitialMessage.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+import { useChatState, useChatActions } from "@yext/chat-headless-react";
+import { useDefaultHandleApiError } from "../hooks/useDefaultHandleApiError";
+
+/**
+ * Sends a request to Chat API to fetch the initial message when the
+ * conversation first start or when the message history is reset.
+ *
+ * @internal
+ *
+ * @param handleError - A function which is called when an error occurs while fetching for initial message.
+ *                      By default, the error is logged to the console and an error message is added to state.
+ * @param stream      - Enable streaming behavior by making a request to Chat Streaming API. Defaults to false.
+ */
+export function useFetchInitialMessage(
+  handleError?: (e: unknown) => void,
+  stream = false
+) {
+  const chat = useChatActions();
+  const defaultHandleApiError = useDefaultHandleApiError();
+  const messages = useChatState((state) => state.conversation.messages);
+  const [fetchInitialMessage, setFetchInitialMessage] = useState(
+    messages.length === 0
+  );
+  const [messagesLength, setMessagesLength] = useState(messages.length);
+  const canSendMessage = useChatState(
+    (state) => state.conversation.canSendMessage
+  );
+
+  //handle message history resets
+  useEffect(() => {
+    const newMessagesLength = messages.length;
+    // Fetch data only when the conversation messages changes from non-zero to zero
+    if (messagesLength > 0 && newMessagesLength === 0) {
+      setFetchInitialMessage(true);
+    }
+    setMessagesLength(newMessagesLength);
+  }, [messages.length, messagesLength]);
+
+  useEffect(() => {
+    if (!fetchInitialMessage || !canSendMessage) {
+      return;
+    }
+    setFetchInitialMessage(false);
+    const res = stream ? chat.streamNextMessage() : chat.getNextMessage();
+    res.catch((e) => (handleError ? handleError(e) : defaultHandleApiError(e)));
+  }, [
+    chat,
+    stream,
+    handleError,
+    defaultHandleApiError,
+    fetchInitialMessage,
+    canSendMessage,
+  ]);
+}


### PR DESCRIPTION
support a new prop field in `ChatPopUp` call `showInitialMessagePopUp`. If true, `ChatPopUp` will display a popup next to the button showing the initial message. This message popup will NOT appear when once the panel is open (either on load or by manual click) or when there's an error fetching the initial message

Also refactored the fetch initial message into its own custom react hook for reusability

J=CLIP-743
TEST=manual&auto

see that tests passed
see that it works in test site

https://github.com/yext/chat-ui-react/assets/36055303/36e3e07a-e7af-47a1-8ba3-dcd9fed9cb68

