### PR TITLE
Fix analytics mock

### DIFF
--- a/tests/__utils__/mocks.ts
+++ b/tests/__utils__/mocks.ts
@@ -6,6 +6,7 @@ import {
   useChatActions,
   useChatState,
 } from "@yext/chat-headless-react";
+import { provideChatAnalytics, ChatAnalyticsService } from "@yext/analytics";
 
 export type RecursivePartial<T> = {
   [P in keyof T]?: T[P] extends undefined
@@ -64,4 +65,17 @@ export function mockChatHooks({
 }) {
   mockedState && mockChatState(mockedState);
   mockedActions && mockChatActions(mockedActions);
+}
+
+export function mockChatAnalytics(
+  customImpl?: typeof provideChatAnalytics
+): jest.SpyInstance<ChatAnalyticsService, unknown[]> {
+  const mockImpl =
+    customImpl ??
+    (() => ({
+      report: jest.fn(),
+    }));
+  return jest
+    .spyOn(require("@yext/analytics"), "provideChatAnalytics")
+    .mockImplementation(mockImpl as (...args: unknown[]) => unknown);
 }

--- a/tests/components/ChatPopUp.test.tsx
+++ b/tests/components/ChatPopUp.test.tsx
@@ -10,11 +10,14 @@ import {
   MessageSource,
   useChatActions,
 } from "@yext/chat-headless-react";
-import { mockChatActions, mockChatState } from "../__utils__/mocks";
-
-jest.mock("@yext/analytics");
+import {
+  mockChatActions,
+  mockChatAnalytics,
+  mockChatState,
+} from "../__utils__/mocks";
 
 beforeEach(() => {
+  mockChatAnalytics();
   mockChatActions({
     getNextMessage: jest.fn(() => Promise.resolve()),
     streamNextMessage: jest.fn(() => Promise.resolve()),
@@ -197,6 +200,7 @@ describe("showUnreadNotification", () => {
 
   it("updates the number of unread messages when new messages are added while panel is closed", async () => {
     jest.resetAllMocks(); // remove mocks to trigger state update
+    mockChatAnalytics();
     const TestTrigger = () => {
       const actions = useChatActions();
       return (


### PR DESCRIPTION
properly mock `"@yext/analytics"` to resolve the error below (although it doesn't affect the unit tests -- it just leave some console errors):

<img width="917" alt="Screenshot 2023-10-31 at 11 33 41 AM" src="https://github.com/yext/chat-ui-react/assets/36055303/1afecc0a-35f6-4b05-b2fd-6ca246813bee">

TEST=auto

see that the errors are gone when running the tests