### PR TITLE
Fix package type exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/chat-ui-react",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/chat-ui-react",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-markdown": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,21 @@
 {
   "name": "@yext/chat-ui-react",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "A library of React Components for powering Yext Chat integrations.",
   "author": "clippy@yext.com",
   "main": "./lib/commonjs/src/index.js",
   "module": "./lib/esm/src/index.mjs",
-  "types": "./lib/esm/src/index.d.ts",
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": "./lib/esm/src/index.mjs",
-      "require": "./lib/commonjs/src/index.js"
+      "import": {
+        "default": "./lib/esm/src/index.mjs",
+        "types": "./lib/esm/index.d.ts"
+      },
+      "require": {
+        "default": "./lib/commonjs/src/index.js",
+        "types": "./lib/commonjs/src/index.d.ts"
+      }
     },
     "./bundle.css": "./lib/bundle.css"
   },


### PR DESCRIPTION
After noticing that types were not appearing properly in our script tag repo, I went down an extraordinary rabbit-hole of module/cjs exports with typescript and came out the other side haunted but enlightened.

You can find a thread on the topic here https://github.com/microsoft/TypeScript/issues/52363

TL;DR of it all is that types work now. More or less.

TEST=manual

I first cross-checked the changes using https://arethetypeswrong.github.io/ and verified that it no longer says it can't find the types.
NOTE: It _does_ say that the new version has a type masquerading as CommonJS which is not great but I tried _several_ permutations in package.json and none of them prevented the masquerade.

Once I was fairly confident I had something, I published the package under 0.8.3-beta.1 and verified that after installing, types worked properly in the script tag. Huzzah!

I am now updating to 0.8.3 properly.