### PR TITLE
add support for Suggested Reply feature

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,6 @@
+Contains information from the language-subtag-registry JSON Database (https://github.com/mattcg/language-subtag-registry/tree/master/data/json)
+which is made available under the ODC Attribution License (https://github.com/mattcg/language-subtag-registry/blob/master/LICENSE.md).
+
 Contains information from the language-subtag-registry JSON Database (https://github.com/mattcg/language-subtag-registry/tree/master/data/json) which is made available under the ODC Attribution License (https://github.com/mattcg/language-subtag-registry/blob/master/LICENSE.md).
 
 The files listed in this repository are licensed under the below license.  All other features and products are subject to separate agreements and certain functionality requires paid subscriptions to Yext products.

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -170,7 +170,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM packages may be included in this product:
 
- - @yext/chat-core@0.7.4
+ - @yext/chat-core@0.7.6
  - @yext/chat-headless-react@0.6.1
  - @yext/chat-headless@0.7.1
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/chat-ui-react",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/chat-ui-react",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-markdown": "^6.0.3",
@@ -8173,9 +8173,9 @@
       }
     },
     "node_modules/@yext/chat-core": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@yext/chat-core/-/chat-core-0.7.4.tgz",
-      "integrity": "sha512-vwyKQ1iHQIi2zpqPADcWM1iIAaiaEXALECclIHwXnnP2FkpHP5PnN5ayp5KHCMMkGftuaXwAuFhIUlQAH6tFrw==",
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/@yext/chat-core/-/chat-core-0.7.6.tgz",
+      "integrity": "sha512-rsZU4mVK6KtAwxTcABvyJIVatRfKPVk58xpFsyw7UoOUhBsT6Sz60WneVm/amvQV9qfCZrK8pljvsKuPaL7PSA==",
       "dev": true,
       "dependencies": {
         "cross-fetch": "^3.1.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-ui-react",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "A library of React Components for powering Yext Chat integrations.",
   "author": "clippy@yext.com",
   "main": "./lib/commonjs/src/index.js",

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -85,6 +85,9 @@ export function ChatPanel(props: ChatPanelProps) {
     props;
   const messages = useChatState((state) => state.conversation.messages);
   const loading = useChatState((state) => state.conversation.isLoading);
+  const suggestedReplies = useChatState(
+    (state) => state.conversation.notes?.suggestedReplies
+  );
   const cssClasses = useComposedCssClasses(builtInCssClasses, customCssClasses);
   const reportAnalyticsEvent = useReportAnalyticsEvent();
   useFetchInitialMessage(handleError, stream);
@@ -102,9 +105,8 @@ export function ChatPanel(props: ChatPanelProps) {
     ) {
       return messageSuggestions;
     }
-    // TODO: Chat API will send suggestions in the message notes eventually; add that here. [CLIP-852]
-    return null;
-  }, [messages, messageSuggestions]);
+    return suggestedReplies;
+  }, [messages, suggestedReplies, messageSuggestions]);
 
   const messagesRef = useRef<Array<HTMLDivElement | null>>([]);
   const messagesContainer = useRef<HTMLDivElement>(null);
@@ -150,15 +152,15 @@ export function ChatPanel(props: ChatPanelProps) {
               </div>
             ))}
             {loading && <LoadingDots />}
-            {suggestions && (
-              <MessageSuggestions
-                suggestions={suggestions}
-                customCssClasses={cssClasses.messageSuggestionClasses}
-              />
-            )}
           </div>
         </div>
         <div className={cssClasses.inputContainer}>
+          {suggestions && (
+            <MessageSuggestions
+              suggestions={suggestions}
+              customCssClasses={cssClasses.messageSuggestionClasses}
+            />
+          )}
           <ChatInput {...props} customCssClasses={cssClasses.inputCssClasses} />
         </div>
       </div>

--- a/src/components/MessageSuggestions.tsx
+++ b/src/components/MessageSuggestions.tsx
@@ -1,5 +1,9 @@
 import React, { useCallback } from "react";
-import { useChatActions } from "@yext/chat-headless-react";
+import {
+  MessageNotes,
+  useChatActions,
+  useChatState,
+} from "@yext/chat-headless-react";
 import { useDefaultHandleApiError } from "../hooks/useDefaultHandleApiError";
 import { withStylelessCssClasses } from "../utils/withStylelessCssClasses";
 import { useComposedCssClasses } from "../hooks";
@@ -27,7 +31,7 @@ export interface MessageSuggestionsProps {
 const defaultClassnames: MessageSuggestionCssClasses = withStylelessCssClasses(
   "Suggestions",
   {
-    container: "flex gap-2 mt-4 w-full overflow-x-auto flex-wrap",
+    container: "flex gap-2 mb-4 w-full overflow-x-auto flex-wrap",
     suggestion:
       "hover:cursor-pointer px-2 py-1 bg-white hover:bg-slate-300 rounded-full text-sm text-blue-700 border border-blue-700 hover:underline",
   }
@@ -44,13 +48,19 @@ export const MessageSuggestions: React.FC<MessageSuggestionsProps> = ({
   customCssClasses,
 }) => {
   const actions = useChatActions();
+  const notes = useChatState((state) => state.conversation.notes);
   const defaultHandleApiError = useDefaultHandleApiError();
   const sendMsg = useCallback(
     (msg: string) => {
+      const newNotes = {
+        ...(notes || {}),
+        suggestedReplies: undefined,
+      } satisfies MessageNotes;
+      actions.setMessageNotes(newNotes);
       const res = actions.getNextMessage(msg);
       res.catch(defaultHandleApiError);
     },
-    [defaultHandleApiError, actions]
+    [actions, notes, defaultHandleApiError]
   );
 
   const classes = useComposedCssClasses(defaultClassnames, customCssClasses);

--- a/test-site/src/App.tsx
+++ b/test-site/src/App.tsx
@@ -28,11 +28,8 @@ function App() {
                 <ChatHeader title="Clippy's Chatbot" showRestartButton={true} />
               }
               messageSuggestions={[
-                "Hello",
-                "How are you?",
-                "Goodbye",
-                "What is your name?",
-                "This is a longer message to test how it scales with more text",
+                "What locations are nearby?",
+                "I'd like to learn more about a location in Arlington",
               ]}
             />
           </div>

--- a/tests/components/MessageSuggestions.test.tsx
+++ b/tests/components/MessageSuggestions.test.tsx
@@ -17,6 +17,7 @@ beforeEach(() => {
     mockedActions: {
       streamNextMessage: jest.fn(() => Promise.resolve()),
       getNextMessage: jest.fn(() => Promise.resolve()),
+      setMessageNotes: jest.fn(),
     },
   });
 });
@@ -28,4 +29,16 @@ it("sends message when pill is clicked", async () => {
   expect(button).toHaveTextContent("test msg");
   await act(() => userEvent.click(button));
   expect(actions.getNextMessage).toHaveBeenCalledTimes(1);
+});
+
+it("clears note replies when pill is clicked", async () => {
+  render(<MessageSuggestions suggestions={["test msg"]} />);
+  const actions = spyOnActions();
+  const button = screen.getByRole("button");
+  expect(button).toHaveTextContent("test msg");
+  await act(() => userEvent.click(button));
+  expect(actions.setMessageNotes).toHaveBeenCalledTimes(1);
+  expect(actions.setMessageNotes).toHaveBeenCalledWith({
+    suggestedReplies: undefined,
+  });
 });


### PR DESCRIPTION
J=CLIP-883

The UI Library now supports suggested replies that are taken from the Chat API response, not just from the initial configuration. Also adjusts the layout so that suggestions are part of the Input panel and not the Messages panel. See below for an example of how it will look.

<img width="763" alt="image" src="https://github.com/yext/chat-ui-react/assets/61058739/910c930d-0400-4a6b-b6f4-b4fa6493a928">

**Note:** Suggested Replies are not expected to be available in the production version of the Yext Chat API until the beginning of 2024, due to a deployment freeze for the holidays.