### PR TITLE
Bug Fix: double initial fetch message from ChatPopup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/chat-ui-react",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/chat-ui-react",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-markdown": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-ui-react",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "A library of React Components for powering Yext Chat integrations.",
   "author": "clippy@yext.com",
   "main": "./lib/commonjs/src/index.js",

--- a/src/components/ChatPopUp.tsx
+++ b/src/components/ChatPopUp.tsx
@@ -147,12 +147,6 @@ export function ChatPopUp(props: ChatPopUpProps) {
   const [numReadMessages, setNumReadMessagesLength] = useState<number>(0);
   const [numUnreadMessages, setNumUnreadMessagesLength] = useState<number>(0);
 
-  useFetchInitialMessage(
-    showInitialMessagePopUp ? console.error : handleError,
-    false,
-    showUnreadNotification || showInitialMessagePopUp
-  );
-
   const [showInitialMessage, setshowInitialMessage] = useState(
     //only show initial message popup (if specified) when CTA label is not provided
     !ctaLabel && showInitialMessagePopUp
@@ -167,6 +161,14 @@ export function ChatPopUp(props: ChatPopUpProps) {
   // control the actual DOM rendering of the panel. Start rendering on first open state
   // to avoid message requests immediately on load while the popup is still "hidden"
   const [renderChat, setRenderChat] = useState(false);
+
+
+  // only fetch initial message when ChatPanel is closed on load (otherwise, it will be fetched in ChatPanel)
+  useFetchInitialMessage(
+    showInitialMessagePopUp ? console.error : handleError,
+    false,
+    (showUnreadNotification || showInitialMessagePopUp) && !renderChat && !openOnLoad,
+  );
 
   // update in useEffect, instead of having openOnLoad as initial state for show/renderChat,
   // in order to maintain the fade-in CSS animation when opening the panel on load
@@ -192,7 +194,7 @@ export function ChatPopUp(props: ChatPopUpProps) {
   }, [customOnClose, messages]);
 
   useEffect(() => {
-    //update number of unread messages if there are new messages added while the panel is closed
+    // update number of unread messages if there are new messages added while the panel is closed
     setNumUnreadMessagesLength(messages.length - numReadMessages);
   }, [messages, numReadMessages]);
 

--- a/src/hooks/useFetchInitialMessage.ts
+++ b/src/hooks/useFetchInitialMessage.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useChatState, useChatActions } from "@yext/chat-headless-react";
 import { useDefaultHandleApiError } from "../hooks/useDefaultHandleApiError";
 
@@ -16,43 +16,20 @@ import { useDefaultHandleApiError } from "../hooks/useDefaultHandleApiError";
 export function useFetchInitialMessage(
   handleError?: (e: unknown) => void,
   stream = false,
-  customCondition = true
+  customCondition = true,
 ) {
   const chat = useChatActions();
   const defaultHandleApiError = useDefaultHandleApiError();
   const messages = useChatState((state) => state.conversation.messages);
-  const [fetchInitialMessage, setFetchInitialMessage] = useState(
-    messages.length === 0
-  );
-  const [messagesLength, setMessagesLength] = useState(messages.length);
   const canSendMessage = useChatState(
     (state) => state.conversation.canSendMessage
   );
-
-  //handle message history resets
+  
   useEffect(() => {
-    const newMessagesLength = messages.length;
-    // Fetch data only when the conversation messages changes from non-zero to zero
-    if (messagesLength > 0 && newMessagesLength === 0) {
-      setFetchInitialMessage(true);
-    }
-    setMessagesLength(newMessagesLength);
-  }, [messages.length, messagesLength]);
-
-  useEffect(() => {
-    if (!fetchInitialMessage || !canSendMessage || !customCondition) {
+    if (messages.length !== 0 || !canSendMessage || !customCondition) {
       return;
     }
-    setFetchInitialMessage(false);
     const res = stream ? chat.streamNextMessage() : chat.getNextMessage();
     res.catch((e) => (handleError ? handleError(e) : defaultHandleApiError(e)));
-  }, [
-    chat,
-    stream,
-    handleError,
-    defaultHandleApiError,
-    fetchInitialMessage,
-    canSendMessage,
-    customCondition,
-  ]);
+  }, [chat, stream, handleError, defaultHandleApiError, canSendMessage, customCondition, messages.length]);
 }

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -23,7 +23,7 @@
     },
     "..": {
       "name": "@yext/chat-ui-react",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-markdown": "^6.0.3",

--- a/test-site/src/App.tsx
+++ b/test-site/src/App.tsx
@@ -1,4 +1,4 @@
-import { ChatPopUp } from "@yext/chat-ui-react";
+import { ChatHeader, ChatPanel, ChatPopUp } from "@yext/chat-ui-react";
 import {
   ChatHeadlessProvider,
   HeadlessConfig,
@@ -19,6 +19,23 @@ const config: HeadlessConfig = {
 function App() {
   return (
     <div>
+      <div className="h-screen w-screen flex justify-center items-center bg-slate-700">
+        {/* <h1 className="external-element">External Element!</h1> */}
+        <ChatHeadlessProvider config={config}>
+          <div className="h-5/6 w-1/2">
+            <ChatPanel
+              header={
+                <ChatHeader title="Clippy's Chatbot" showRestartButton={true} />
+              }
+              messageSuggestions={[
+                "What locations are nearby?",
+                "I'd like to learn more about a location in Arlington",
+              ]}
+              footer="This is a test footer with [link](https://yext.com) and [another link](https://yext.com)"
+            />
+          </div>
+        </ChatHeadlessProvider>
+      </div>
       <ChatHeadlessProvider config={config}>
         <ChatPopUp
           title="Clippy"

--- a/test-site/src/App.tsx
+++ b/test-site/src/App.tsx
@@ -1,4 +1,4 @@
-import { ChatHeader, ChatPanel, ChatPopUp } from "@yext/chat-ui-react";
+import { ChatPopUp } from "@yext/chat-ui-react";
 import {
   ChatHeadlessProvider,
   HeadlessConfig,
@@ -19,26 +19,13 @@ const config: HeadlessConfig = {
 function App() {
   return (
     <div>
-      <div className="h-screen w-screen flex justify-center items-center bg-slate-700">
-        {/* <h1 className="external-element">External Element!</h1> */}
-        <ChatHeadlessProvider config={config}>
-          <div className="h-5/6 w-1/2">
-            <ChatPanel
-              header={
-                <ChatHeader title="Clippy's Chatbot" showRestartButton={true} />
-              }
-              messageSuggestions={[
-                "What locations are nearby?",
-                "I'd like to learn more about a location in Arlington",
-              ]}
-              footer="This is a test footer with [link](https://yext.com) and [another link](https://yext.com)"
-            />
-          </div>
-        </ChatHeadlessProvider>
-      </div>
       <ChatHeadlessProvider config={config}>
         <ChatPopUp
           title="Clippy"
+          openOnLoad={true}
+          showInitialMessagePopUp={true}
+          showHeartBeatAnimation={true}
+          showUnreadNotification={true}
           messageSuggestions={[
             "hey how are you",
             "I'm looking to order a pair of all-mountain skis",


### PR DESCRIPTION
when `openOnLoad` and `showUnreadNotification` prop are both in use, initial message was fetched twice -- once from ChatPopUp component and once from ChatPanel. This is because useFetchInitialMessage doesn't share state between the two component.

This PR updates it so ChatPopUp component only fetch when ChatPanel is not render, otherwise ChatPanel should always do the fetching of the initial message

J=CLIP-1231
TEST=manual

see that it works with both `openOnLoad` and `showUnreadNotification` on

https://github.com/yext/chat-ui-react/assets/36055303/12ccb877-8665-4f8e-a5bc-3e883391f857

