### PR TITLE
Patch input to handle Enter event for japanese keyboards correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/chat-ui-react",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/chat-ui-react",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-markdown": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-ui-react",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "A library of React Components for powering Yext Chat integrations.",
   "author": "clippy@yext.com",
   "main": "./lib/commonjs/src/index.js",

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -106,7 +106,12 @@ export function ChatInput({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (!e.shiftKey && e.key === "Enter") {
+      if (!e.shiftKey && e.key === "Enter" && 
+        // The Japanese Keyboard uses "Enter" key to convert from Hiragana to Kanji.
+        // "isComposing" is a flag that indicates whether the event is part of an ongoing composition session.
+        // Safari does not support `isComposing` with the Japanese IME event,
+        // so we have to additionally check for the keyCode to handle that edge case.
+        !(e.nativeEvent.isComposing || e.keyCode === 229)) {
         e.preventDefault();
         if (canSendMessage && input.trim().length !== 0) {
           sendMessage();


### PR DESCRIPTION
For a clear summary of the issue and the solution, see below:

https://dninomiya.github.io/form-guide/stop-enter-submit

Tested via our dev page using the japanese keyboard - I hit enter and verified that it converted the characters but did not send a message. Subsequently hitting Enter correctly sent the message.

I also double-checked that other keyboards (english) still only require one press of the Enter key, so this should be a completely invisible change to anyone using other languages.