### PR TITLE
ChatPopUp: Open panel on load when there are saved messages in browser storage

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -142,8 +142,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 The following NPM packages may be included in this product:
 
  - @yext/chat-core@0.8.0
- - @yext/chat-headless-react@0.7.0
- - @yext/chat-headless@0.8.0
+ - @yext/chat-headless-react@0.8.0
+ - @yext/chat-headless@0.9.0
 
 These packages each contain the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/chat-ui-react",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/chat-ui-react",
-      "version": "0.9.3",
+      "version": "0.10.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-markdown": "^6.0.3",
@@ -37,7 +37,7 @@
         "@testing-library/user-event": "^14.4.3",
         "@types/jest": "^29.5.1",
         "@types/react": "^18.2.7",
-        "@yext/chat-headless-react": "^0.7.0",
+        "@yext/chat-headless-react": "^0.8.0",
         "@yext/eslint-config": "^1.0.0",
         "babel-jest": "^29.5.0",
         "eslint": "^8.39.0",
@@ -8182,9 +8182,9 @@
       }
     },
     "node_modules/@yext/chat-headless": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@yext/chat-headless/-/chat-headless-0.8.0.tgz",
-      "integrity": "sha512-2KSrIpnkMOvC8anQJ/VkYhH1VNeOA4Zka5h+HU0STXldtLZ3hKSlSufd/87qR+ie1M3xgcrlZHGBHX8fB2FOyw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@yext/chat-headless/-/chat-headless-0.9.0.tgz",
+      "integrity": "sha512-fwtmXoyVV30+xlTxjIxFAd+gmMNLGsnpoGT6OZMxG5v0kKJIvLHn9Ss8c0jXr/c+T/yG9i3fbWzV9i0usT6k9Q==",
       "dev": true,
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
@@ -8193,13 +8193,13 @@
       }
     },
     "node_modules/@yext/chat-headless-react": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@yext/chat-headless-react/-/chat-headless-react-0.7.0.tgz",
-      "integrity": "sha512-4aYNFL2uGApSrTeX6Nf2OOoDhv6YDEfBROsMCWBBRwuo9hEbn574Z3FHr68IjNy/0v8zDid6oektrV1MEhWkrA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@yext/chat-headless-react/-/chat-headless-react-0.8.0.tgz",
+      "integrity": "sha512-BbVI4kjDUIXCqJvkJhfW5P6rag0JjZCQW+jh/fg0EqSV5XoXT6XK2N86f09dowvBkDethA5ISPFlBfyfqlmV2A==",
       "dev": true,
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
-        "@yext/chat-headless": "^0.8.0",
+        "@yext/chat-headless": "^0.9.0",
         "react-redux": "^8.0.5"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-ui-react",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "description": "A library of React Components for powering Yext Chat integrations.",
   "author": "clippy@yext.com",
   "main": "./lib/commonjs/src/index.js",
@@ -69,7 +69,7 @@
     "@testing-library/user-event": "^14.4.3",
     "@types/jest": "^29.5.1",
     "@types/react": "^18.2.7",
-    "@yext/chat-headless-react": "^0.7.0",
+    "@yext/chat-headless-react": "^0.8.0",
     "@yext/eslint-config": "^1.0.0",
     "babel-jest": "^29.5.0",
     "eslint": "^8.39.0",

--- a/src/components/ChatPopUp.tsx
+++ b/src/components/ChatPopUp.tsx
@@ -155,7 +155,7 @@ export function ChatPopUp(props: ChatPopUpProps) {
     setshowInitialMessage(false);
   }, []);
 
-  // control CSS behavior on open/close state of the panel
+  // control CSS behavior (fade-in/out animation) on open/close state of the panel.
   const [showChat, setShowChat] = useState(false);
 
   // control the actual DOM rendering of the panel. Start rendering on first open state
@@ -170,21 +170,20 @@ export function ChatPopUp(props: ChatPopUpProps) {
     (showUnreadNotification || showInitialMessagePopUp) && !renderChat && !openOnLoad,
   );
 
-  // update in useEffect, instead of having openOnLoad as initial state for show/renderChat,
-  // in order to maintain the fade-in CSS animation when opening the panel on load
   useEffect(() => {
-    if (openOnLoad) {
+    // Open panel on load if openOnLoad prop is true or there are messages in state (from browser storage)
+    if (!renderChat && (openOnLoad || messages.length > 1)) {
       setShowChat(true);
       setRenderChat(true);
       setshowInitialMessage(false);
     }
-  }, [openOnLoad]);
+  }, [messages.length, openOnLoad, renderChat]);
 
   const onClick = useCallback(() => {
-    setShowChat(!showChat);
+    setShowChat(prev => !prev);
     setRenderChat(true);
     setshowInitialMessage(false);
-  }, [showChat]);
+  }, []);
 
   const onClose = useCallback(() => {
     setShowChat(false);

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -23,7 +23,7 @@
     },
     "..": {
       "name": "@yext/chat-ui-react",
-      "version": "0.9.2",
+      "version": "0.10.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-markdown": "^6.0.3",
@@ -54,7 +54,7 @@
         "@testing-library/user-event": "^14.4.3",
         "@types/jest": "^29.5.1",
         "@types/react": "^18.2.7",
-        "@yext/chat-headless-react": "^0.7.0",
+        "@yext/chat-headless-react": "^0.8.0",
         "@yext/eslint-config": "^1.0.0",
         "babel-jest": "^29.5.0",
         "eslint": "^8.39.0",

--- a/tests/components/ChatPopUp.test.tsx
+++ b/tests/components/ChatPopUp.test.tsx
@@ -27,7 +27,7 @@ beforeEach(() => {
 
 const dummyConfig: HeadlessConfig = {
   apiKey: "",
-  botId: "",
+  botId: "DUMMY_BOT_ID",
 };
 
 it("toggles display and hide css classes when click on popup button", async () => {
@@ -74,6 +74,35 @@ describe("openOnLoad", () => {
 
   it("does not render panel on load when openOnLoad is false", async () => {
     renderPopUp({ openOnLoad: false });
+    expect(screen.queryByLabelText("Send Message")).toBeNull();
+  });
+});
+
+describe("open on load with state from browser storage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  it("renders panel on load when there are non-initial messages in state", async () => {
+    localStorage.setItem(`yext_chat_state__localhost__${dummyConfig.botId}`, JSON.stringify({
+      messages: [
+        {
+          text: "How can I help you?",
+          source: MessageSource.BOT,
+          timestamp: new Date().toISOString(),
+        },
+        {
+          text: "Hello!",
+          source: MessageSource.USER,
+          timestamp: new Date().toISOString(),
+        }
+      ]
+    }));
+    renderPopUp({}, undefined, { ...dummyConfig, saveToLocalStorage: true });
+    expect(screen.getByLabelText("Send Message")).toBeTruthy();
+  });
+
+  it("does not render panel on load when are no non-initial messages in state", async () => {
+    renderPopUp();
     expect(screen.queryByLabelText("Send Message")).toBeNull();
   });
 });
@@ -232,9 +261,9 @@ describe("showUnreadNotification", () => {
   });
 });
 
-function renderPopUp(props?: Partial<ChatPopUpProps>, children?: JSX.Element) {
+function renderPopUp(props?: Partial<ChatPopUpProps>, children?: JSX.Element, config = dummyConfig) {
   render(
-    <ChatHeadlessProvider config={dummyConfig}>
+    <ChatHeadlessProvider config={config}>
       <ChatPopUp {...props} title="Test Popup" />
       {children}
     </ChatHeadlessProvider>


### PR DESCRIPTION
J=CLIP-1273
TEST=auto&manual

added new unit tests
see that behavior works as expected in test-site. Open on load when there are non-initial messages saved in local storage. Otherwise, the panel remain close until user click open.