### PR TITLE
agent client support

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -141,9 +141,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM packages may be included in this product:
 
- - @yext/chat-core@0.8.0
- - @yext/chat-headless-react@0.8.0
- - @yext/chat-headless@0.9.0
+ - @yext/chat-core@0.8.2
+ - @yext/chat-headless-react@0.9.0
+ - @yext/chat-headless@0.10.0
 
 These packages each contain the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/chat-ui-react",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/chat-ui-react",
-      "version": "0.10.2",
+      "version": "0.11.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-markdown": "^6.0.3",
@@ -37,7 +37,7 @@
         "@testing-library/user-event": "^14.4.3",
         "@types/jest": "^29.5.1",
         "@types/react": "^18.2.7",
-        "@yext/chat-headless-react": "^0.8.0",
+        "@yext/chat-headless-react": "^0.9.0",
         "@yext/eslint-config": "^1.0.0",
         "babel-jest": "^29.5.0",
         "eslint": "^8.39.0",
@@ -59,7 +59,7 @@
         "typescript": "^5.0.4"
       },
       "peerDependencies": {
-        "@yext/chat-headless-react": "^0.8.0",
+        "@yext/chat-headless-react": "^0.9.0",
         "react": "^16.14 || ^17 || ^18",
         "react-dom": "^16.14 || ^17 || || ^18"
       }
@@ -8173,33 +8173,33 @@
       }
     },
     "node_modules/@yext/chat-core": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@yext/chat-core/-/chat-core-0.8.0.tgz",
-      "integrity": "sha512-LTm/i3YLBLSebkQ8rxqlPRyiTNvcqLiIQEjhU8n9pSp2IZVpgqCm6dH6fJ67XZ1L1OZFjF6TeKpV1qpkuzhj+g==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@yext/chat-core/-/chat-core-0.8.2.tgz",
+      "integrity": "sha512-+ivq2xEHY1sGLOlPQ7d5wnlswsZfdO/Hz1Y8cmgq5UP6cpr4wUBTTQd5yWn1u9JJHq38/jcRleC2TSrh8E2Ozg==",
       "dev": true,
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
     },
     "node_modules/@yext/chat-headless": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@yext/chat-headless/-/chat-headless-0.9.0.tgz",
-      "integrity": "sha512-fwtmXoyVV30+xlTxjIxFAd+gmMNLGsnpoGT6OZMxG5v0kKJIvLHn9Ss8c0jXr/c+T/yG9i3fbWzV9i0usT6k9Q==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@yext/chat-headless/-/chat-headless-0.10.0.tgz",
+      "integrity": "sha512-rYabLNfU8KcMDw/HqAkWbFuu2AavSjEtU5kYYAVdTRcS3LyrsNXe/l7lp11R3RCmJCcJnn5TXqhcTKzfI8I9zA==",
       "dev": true,
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
         "@yext/analytics": "^0.6.3",
-        "@yext/chat-core": "^0.8.0"
+        "@yext/chat-core": "^0.8.2"
       }
     },
     "node_modules/@yext/chat-headless-react": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@yext/chat-headless-react/-/chat-headless-react-0.8.0.tgz",
-      "integrity": "sha512-BbVI4kjDUIXCqJvkJhfW5P6rag0JjZCQW+jh/fg0EqSV5XoXT6XK2N86f09dowvBkDethA5ISPFlBfyfqlmV2A==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@yext/chat-headless-react/-/chat-headless-react-0.9.0.tgz",
+      "integrity": "sha512-8JaLGsAm6YW6fNKZqOzMQOM/i3HcbEND8M4WCvt8lz4kLqV0qeA8KsBZWEM7NX7/rGafwzeLQzYGD8B1EW7Jfg==",
       "dev": true,
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
-        "@yext/chat-headless": "^0.9.0",
+        "@yext/chat-headless": "^0.10.0",
         "react-redux": "^8.0.5"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-ui-react",
-  "version": "0.10.3",
+  "version": "0.11.0",
   "description": "A library of React Components for powering Yext Chat integrations.",
   "author": "clippy@yext.com",
   "main": "./lib/commonjs/src/index.js",
@@ -69,7 +69,7 @@
     "@testing-library/user-event": "^14.4.3",
     "@types/jest": "^29.5.1",
     "@types/react": "^18.2.7",
-    "@yext/chat-headless-react": "^0.8.0",
+    "@yext/chat-headless-react": "^0.9.0",
     "@yext/eslint-config": "^1.0.0",
     "babel-jest": "^29.5.0",
     "eslint": "^8.39.0",
@@ -91,7 +91,7 @@
     "typescript": "^5.0.4"
   },
   "peerDependencies": {
-    "@yext/chat-headless-react": "^0.8.0",
+    "@yext/chat-headless-react": "^0.9.0",
     "react": "^16.14 || ^17 || ^18",
     "react-dom": "^16.14 || ^17 || || ^18"
   },

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -45,10 +45,10 @@ const builtInCssClasses: ChatPanelCssClasses = withStylelessCssClasses(
   {
     container: "h-full w-full flex flex-col relative shadow-2xl bg-white",
     messagesScrollContainer: "flex flex-col mt-auto overflow-hidden",
-    messagesContainer: "flex flex-col gap-y-1 px-4 overflow-auto",
+    messagesContainer: "flex flex-col gap-y-1 px-4 overflow-auto [&>*:first-child]:mt-3",
     inputContainer: "w-full p-4",
     messageBubbleCssClasses: {
-      topContainer: "first:mt-4",
+      topContainer: "mt-1",
     },
     footer: "text-center text-slate-400 rounded-b-3xl px-4 pb-4 text-[12px]",
   }

--- a/src/components/ChatPopUp.tsx
+++ b/src/components/ChatPopUp.tsx
@@ -70,7 +70,6 @@ const builtInCssClasses: ChatPopUpCssClasses = withStylelessCssClasses(
     panelCssClasses: {
       container: "max-[480px]:rounded-none rounded-3xl",
       inputContainer: "max-[480px]:rounded-none rounded-b-3xl",
-      messagesScrollContainer: "rounded-b-3xl",
     },
   }
 );

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -43,7 +43,7 @@ const builtInCssClasses: MessageBubbleCssClasses =
     text__bot: "text-slate-900",
     text__user: "text-white break-words",
     timestamp:
-      "w-fit my-0.5 ml-4 @lg:ml-0 text-slate-400 text-[10px] @[480px]:text-[13px] opacity-0 peer-hover:opacity-100 duration-200 whitespace-pre-wrap",
+      "w-fit ml-4 @lg:ml-0 text-slate-400 text-[10px] @[480px]:text-[13px] opacity-0 peer-hover:opacity-100 duration-200 whitespace-pre-wrap",
     timestamp__bot: "",
     timestamp__user: "ml-auto",
     feedbackButtonsCssClasses: {},

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -23,7 +23,7 @@
     },
     "..": {
       "name": "@yext/chat-ui-react",
-      "version": "0.10.2",
+      "version": "0.11.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-markdown": "^6.0.3",
@@ -54,7 +54,7 @@
         "@testing-library/user-event": "^14.4.3",
         "@types/jest": "^29.5.1",
         "@types/react": "^18.2.7",
-        "@yext/chat-headless-react": "^0.8.0",
+        "@yext/chat-headless-react": "^0.9.0",
         "@yext/eslint-config": "^1.0.0",
         "babel-jest": "^29.5.0",
         "eslint": "^8.39.0",
@@ -76,7 +76,7 @@
         "typescript": "^5.0.4"
       },
       "peerDependencies": {
-        "@yext/chat-headless-react": "^0.8.0",
+        "@yext/chat-headless-react": "^0.9.0",
         "react": "^16.14 || ^17 || ^18",
         "react-dom": "^16.14 || ^17 || || ^18"
       }


### PR DESCRIPTION
bump chat-headless-react version to be compatible with the version that supports agent client

also adjusted styling to reduce the margin gap between message bubbles, especially multiple ones from the same source.

J=CLIP-1328
TEST=manual

see it works as expected through test-site using chat-core-aws-connect as the agent client