### PR TITLE
Address rollup vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "prettier": "^2.8.8",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "rollup": "^3.28.1",
+        "rollup": "^3.29.5",
         "rollup-plugin-typescript2": "^0.35.0",
         "storybook": "^7.5.2",
         "tailwindcss": "^3.3.2",
@@ -19274,9 +19274,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.28.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.28.1.tgz",
-      "integrity": "sha512-R9OMQmIHJm9znrU3m3cpE8uhN0fGdXiawME7aZIpQqvpS/85+Vt1Hq1/yVIcYfOmaQiHjvXkQAoJukvLpau6Yw==",
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
+      "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "prettier": "^2.8.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "rollup": "^3.28.1",
+    "rollup": "^3.29.5",
     "rollup-plugin-typescript2": "^0.35.0",
     "storybook": "^7.5.2",
     "tailwindcss": "^3.3.2",

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -23,7 +23,7 @@
     },
     "..": {
       "name": "@yext/chat-ui-react",
-      "version": "0.11.3",
+      "version": "0.11.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-markdown": "^6.0.3",
@@ -69,7 +69,7 @@
         "prettier": "^2.8.8",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "rollup": "^3.28.1",
+        "rollup": "^3.29.5",
         "rollup-plugin-typescript2": "^0.35.0",
         "storybook": "^7.5.2",
         "tailwindcss": "^3.3.2",


### PR DESCRIPTION
update rollup version to 3.29.5 (https://github.com/rollup/rollup/releases/tag/v3.29.5) which includes a vulnerability fix

J=VULN-39403,VULN-39404
TEST=manual

built package, smoke test using test-site