### PR TITLE
Add support to save chat panel's scroll position

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/chat-ui-react",
-  "version": "0.11.5",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/chat-ui-react",
-      "version": "0.11.5",
+      "version": "0.12.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-markdown": "^6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/chat-ui-react",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/chat-ui-react",
-      "version": "0.11.4",
+      "version": "0.11.5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-markdown": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-ui-react",
-  "version": "0.11.5",
+  "version": "0.12.0",
   "description": "A library of React Components for powering Yext Chat integrations.",
   "author": "clippy@yext.com",
   "main": "./lib/commonjs/src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-ui-react",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "A library of React Components for powering Yext Chat integrations.",
   "author": "clippy@yext.com",
   "main": "./lib/commonjs/src/index.js",

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -211,14 +211,18 @@ export function ChatPanel(props: ChatPanelProps) {
 
   useLayoutEffect(() => {
     const curr = messagesContainer.current;
-    curr?.addEventListener("scroll", () => {
+    const onScroll = () => {
       if (!conversationId) {
         return;
       }
       saveSessionState(conversationId, {
-        scrollPosition: curr.scrollTop,
+        scrollPosition: curr?.scrollTop,
       });
-    });
+    }
+    curr?.addEventListener("scroll", onScroll);
+    return () => {
+      curr?.removeEventListener("scroll", onScroll);
+    };
   }, [messagesContainer, conversationId]);
 
   return (

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -165,11 +165,11 @@ export function ChatPanel(props: ChatPanelProps) {
   const [initialMessagesLength] = useState(messages.length);
 
   const savedPanelState = useMemo(() => {
-    if (!conversationId || !messages.length) {
+    if (!conversationId) {
       return {};
     }
     return loadSessionState(conversationId);
-  }, [conversationId, messages]);
+  }, [conversationId]);
 
   // Handle scrolling when messages change
   useEffect(() => {
@@ -218,7 +218,7 @@ export function ChatPanel(props: ChatPanelProps) {
       saveSessionState(conversationId, {
         scrollPosition: curr?.scrollTop,
       });
-    }
+    };
     curr?.addEventListener("scroll", onScroll);
     return () => {
       curr?.removeEventListener("scroll", onScroll);
@@ -230,7 +230,11 @@ export function ChatPanel(props: ChatPanelProps) {
       <div className={cssClasses.container}>
         {header}
         <div className={cssClasses.messagesScrollContainer}>
-          <div ref={messagesContainer} className={cssClasses.messagesContainer}>
+          <div
+            ref={messagesContainer}
+            className={cssClasses.messagesContainer}
+            aria-label="Chat Panel Messages Container"
+          >
             {messages.map((message, index) => (
               <div key={index} ref={setMessagesRef(index)}>
                 <MessageBubble
@@ -334,17 +338,6 @@ export const saveSessionState = (conversationId: string, state: PanelState) => {
   const hostname = window?.location?.hostname;
   if (!localStorage || !hostname) {
     return;
-  }
-  const previousState = localStorage.getItem(
-    getStateLocalStorageKey(hostname, conversationId)
-  );
-
-  if (previousState) {
-    try {
-      state = { ...JSON.parse(previousState), ...state };
-    } catch (e) {
-      console.warn("Unabled to load saved panel state: error parsing state.");
-    }
   }
   localStorage.setItem(
     getStateLocalStorageKey(hostname, conversationId),

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -5,6 +5,7 @@ import React, {
   useMemo,
   useRef,
   useState,
+  useLayoutEffect,
 } from "react";
 import { useChatState } from "@yext/chat-headless-react";
 import {
@@ -215,7 +216,7 @@ export function ChatPanel(props: ChatPanelProps) {
     [cssClasses]
   );
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const curr = messagesContainer.current;
     curr?.addEventListener("scroll", () => {
       if (!conversationId) {

--- a/tests/components/ChatPanel.test.tsx
+++ b/tests/components/ChatPanel.test.tsx
@@ -214,12 +214,6 @@ describe("loadSessionState works as expected", () => {
       messages: [{ ...dummyMessage, timestamp: new Date().toISOString() }],
     },
   };
-  const mockOldConvoState = {
-    conversation: {
-      conversationId: mockConvoId,
-      messages: [dummyMessage],
-    },
-  };
 
   it("saves panel state to local storage", () => {
     mockChatState(mockConvoState);
@@ -295,18 +289,6 @@ describe("loadSessionState works as expected", () => {
     expect(consoleWarnSpy).toBeCalledWith(
       "Unabled to load saved panel state: error parsing state."
     );
-  });
-
-  it("ignores and removes state when loading saved state older than 24 hours", () => {
-    mockChatState(mockOldConvoState);
-    localStorage.setItem(mockKey, JSON.stringify(mockPanelState));
-    const storageGetSpy = jest.spyOn(Storage.prototype, "getItem");
-    const storageRemoveSpy = jest.spyOn(Storage.prototype, "removeItem");
-
-    render(<ChatPanel />);
-    expect(storageGetSpy).toHaveBeenCalledWith(mockKey);
-    expect(storageRemoveSpy).toHaveBeenCalledWith(mockKey);
-    expect(localStorage.getItem(mockKey)).toBeNull();
   });
 });
 

--- a/tests/components/ChatPanel.test.tsx
+++ b/tests/components/ChatPanel.test.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable testing-library/no-unnecessary-act */
-/* eslint-disable testing-library/no-node-access */
 import {
   act,
   render,
@@ -219,8 +218,8 @@ describe("loadSessionState works as expected", () => {
     mockChatState(mockConvoState);
     const storageSetSpy = jest.spyOn(Storage.prototype, "setItem");
 
-    const { container } = render(<ChatPanel />);
-    const scrollDiv = getChatPanelScrollDiv(container);
+    render(<ChatPanel />);
+    const scrollDiv = screen.getByLabelText("Chat Panel Messages Container");
 
     fireEvent.scroll(scrollDiv, {
       target: { scrollTop: mockPanelState.scrollPosition },
@@ -247,32 +246,6 @@ describe("loadSessionState works as expected", () => {
     );
   });
 
-  it("handles invalid state in local storage when saving new state", () => {
-    mockChatState(mockConvoState);
-    localStorage.setItem(mockKey, "hello world");
-    const storageSetSpy = jest.spyOn(Storage.prototype, "setItem");
-    const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation();
-    const { container } = render(<ChatPanel />);
-    const scrollDiv = getChatPanelScrollDiv(container);
-
-    fireEvent.scroll(scrollDiv, {
-      target: { scrollTop: mockPanelState.scrollPosition },
-    });
-
-    expect(storageSetSpy).toHaveBeenCalledWith(
-      mockKey,
-      JSON.stringify(mockPanelState)
-    );
-    expect(localStorage.getItem(mockKey)).toEqual(
-      JSON.stringify(mockPanelState)
-    );
-
-    expect(consoleWarnSpy).toBeCalledTimes(1);
-    expect(consoleWarnSpy).toBeCalledWith(
-      "Unabled to load saved panel state: error parsing state."
-    );
-  });
-
   it("handles invalid state in local storage when loading saved state", () => {
     mockChatState(mockConvoState);
     localStorage.setItem(mockKey, "hello world");
@@ -291,9 +264,3 @@ describe("loadSessionState works as expected", () => {
     );
   });
 });
-
-const getChatPanelScrollDiv = (chatPanelContainer: HTMLElement) => {
-  return chatPanelContainer.getElementsByClassName(
-    "yext-chat-panel__messages-container"
-  )[0];
-};

--- a/tests/components/ChatPanel.test.tsx
+++ b/tests/components/ChatPanel.test.tsx
@@ -1,5 +1,12 @@
 /* eslint-disable testing-library/no-unnecessary-act */
-import { act, render, screen, waitFor } from "@testing-library/react";
+/* eslint-disable testing-library/no-node-access */
+import {
+  act,
+  render,
+  screen,
+  waitFor,
+  fireEvent,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ChatPanel } from "../../src";
 import {
@@ -9,6 +16,10 @@ import {
   spyOnActions,
 } from "../__utils__/mocks";
 import { Message, MessageSource } from "@yext/chat-headless-react";
+import {
+  PanelState,
+  getStateLocalStorageKey,
+} from "../../src/components/ChatPanel";
 
 const dummyMessage: Message = {
   timestamp: "2023-05-31T14:22:19.376Z",
@@ -188,3 +199,119 @@ it("applies link target setting (default blank)", async () => {
   render(<ChatPanel />);
   expect(screen.getByText("msg link")).toHaveAttribute("target", "_blank");
 });
+
+describe("loadSessionState works as expected", () => {
+  const jestHostname = "localhost";
+  window.location.hostname = jestHostname;
+  const mockConvoId = "dummy-id";
+  const mockKey = getStateLocalStorageKey(jestHostname, mockConvoId);
+  const mockPanelState: PanelState = {
+    scrollPosition: 23,
+  };
+  const mockConvoState = {
+    conversation: {
+      conversationId: mockConvoId,
+      messages: [{ ...dummyMessage, timestamp: new Date().toISOString() }],
+    },
+  };
+  const mockOldConvoState = {
+    conversation: {
+      conversationId: mockConvoId,
+      messages: [dummyMessage],
+    },
+  };
+
+  it("saves panel state to local storage", () => {
+    mockChatState(mockConvoState);
+    const storageSetSpy = jest.spyOn(Storage.prototype, "setItem");
+
+    const { container } = render(<ChatPanel />);
+    const scrollDiv = getChatPanelScrollDiv(container);
+
+    fireEvent.scroll(scrollDiv, {
+      target: { scrollTop: mockPanelState.scrollPosition },
+    });
+
+    expect(storageSetSpy).toHaveBeenCalledWith(
+      mockKey,
+      JSON.stringify(mockPanelState)
+    );
+    expect(localStorage.getItem(mockKey)).toEqual(
+      JSON.stringify(mockPanelState)
+    );
+  });
+
+  it("loads panel from local storage", () => {
+    mockChatState(mockConvoState);
+    localStorage.setItem(mockKey, JSON.stringify(mockPanelState));
+    const storageGetSpy = jest.spyOn(Storage.prototype, "getItem");
+
+    render(<ChatPanel />);
+    expect(storageGetSpy).toHaveBeenCalledWith(mockKey);
+    expect(localStorage.getItem(mockKey)).toEqual(
+      JSON.stringify(mockPanelState)
+    );
+  });
+
+  it("handles invalid state in local storage when saving new state", () => {
+    mockChatState(mockConvoState);
+    localStorage.setItem(mockKey, "hello world");
+    const storageSetSpy = jest.spyOn(Storage.prototype, "setItem");
+    const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation();
+    const { container } = render(<ChatPanel />);
+    const scrollDiv = getChatPanelScrollDiv(container);
+
+    fireEvent.scroll(scrollDiv, {
+      target: { scrollTop: mockPanelState.scrollPosition },
+    });
+
+    expect(storageSetSpy).toHaveBeenCalledWith(
+      mockKey,
+      JSON.stringify(mockPanelState)
+    );
+    expect(localStorage.getItem(mockKey)).toEqual(
+      JSON.stringify(mockPanelState)
+    );
+
+    expect(consoleWarnSpy).toBeCalledTimes(1);
+    expect(consoleWarnSpy).toBeCalledWith(
+      "Unabled to load saved panel state: error parsing state."
+    );
+  });
+
+  it("handles invalid state in local storage when loading saved state", () => {
+    mockChatState(mockConvoState);
+    localStorage.setItem(mockKey, "hello world");
+    const storageGetSpy = jest.spyOn(Storage.prototype, "getItem");
+    const storageRemoveSpy = jest.spyOn(Storage.prototype, "removeItem");
+    const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation();
+    render(<ChatPanel />);
+
+    expect(storageGetSpy).toHaveBeenCalledWith(mockKey);
+    expect(storageRemoveSpy).toHaveBeenCalledWith(mockKey);
+    expect(localStorage.getItem(mockKey)).toBeNull();
+
+    expect(consoleWarnSpy).toBeCalledTimes(1);
+    expect(consoleWarnSpy).toBeCalledWith(
+      "Unabled to load saved panel state: error parsing state."
+    );
+  });
+
+  it("ignores and removes state when loading saved state older than 24 hours", () => {
+    mockChatState(mockOldConvoState);
+    localStorage.setItem(mockKey, JSON.stringify(mockPanelState));
+    const storageGetSpy = jest.spyOn(Storage.prototype, "getItem");
+    const storageRemoveSpy = jest.spyOn(Storage.prototype, "removeItem");
+
+    render(<ChatPanel />);
+    expect(storageGetSpy).toHaveBeenCalledWith(mockKey);
+    expect(storageRemoveSpy).toHaveBeenCalledWith(mockKey);
+    expect(localStorage.getItem(mockKey)).toBeNull();
+  });
+});
+
+const getChatPanelScrollDiv = (chatPanelContainer: HTMLElement) => {
+  return chatPanelContainer.getElementsByClassName(
+    "yext-chat-panel__messages-container"
+  )[0];
+};


### PR DESCRIPTION
J=CLIP-1675
TEST=manual,auto

verified on test-site that the panel remains at the correct scroll position after being reloaded/opened in another tab. Also verified that multiple bot panels do not override each other scroll position.

added and ran unit test
https://github.com/user-attachments/assets/d3ade9aa-02e0-445b-b32d-ca1926bf5d4b



