### PR TITLE
chat-ui-react: update chat-headless-react dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ storybook-static/
 .DS_Store
 .env
 .vscode
+.idea

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -62,7 +62,7 @@ SOFTWARE.
 The following NPM packages may be included in this product:
 
  - @types/hast@2.3.4
- - @types/hoist-non-react-statics@3.3.5
+ - @types/hoist-non-react-statics@3.3.6
  - @types/mdast@3.0.11
  - @types/parse5@5.0.3
  - @types/prop-types@15.7.5
@@ -100,7 +100,7 @@ MIT License
 
 The following NPM package may be included in this product:
 
- - @yext/analytics@0.6.6
+ - @yext/analytics@1.0.1
 
 This package contains the following license and notice below:
 
@@ -141,9 +141,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM packages may be included in this product:
 
- - @yext/chat-core@0.8.2
- - @yext/chat-headless-react@0.9.1
- - @yext/chat-headless@0.10.1
+ - @yext/chat-core@0.9.1
+ - @yext/chat-headless-react@0.9.5
+ - @yext/chat-headless@0.12.2
 
 These packages each contain the following license and notice below:
 
@@ -277,7 +277,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 The following NPM package may be included in this product:
 
- - cross-fetch@3.1.8
+ - cross-fetch@3.2.0
 
 This package contains the following license and notice below:
 
@@ -798,7 +798,7 @@ THE SOFTWARE.
 
 The following NPM package may be included in this product:
 
- - layerr@2.1.0
+ - layerr@3.0.0
 
 This package contains the following license and notice below:
 
@@ -1083,7 +1083,7 @@ SOFTWARE.
 
 The following NPM package may be included in this product:
 
- - node-fetch@2.6.12
+ - node-fetch@2.7.0
 
 This package contains the following license and notice below:
 
@@ -1207,7 +1207,6 @@ The following NPM packages may be included in this product:
  - react-is@18.2.0
  - react@18.2.0
  - scheduler@0.23.0
- - use-sync-external-store@1.2.2
 
 These packages each contain the following license and notice below:
 
@@ -1754,7 +1753,7 @@ THE SOFTWARE.
 
 The following NPM package may be included in this product:
 
- - ulidx@2.3.0
+ - ulidx@2.4.1
 
 This package contains the following license and notice below:
 
@@ -1925,6 +1924,36 @@ This package contains the following license and notice below:
 # use-latest
 
 A React helper hook for storing latest value in ref object (updated in useEffect's callback).
+
+-----------
+
+The following NPM package may be included in this product:
+
+ - use-sync-external-store@1.4.0
+
+This package contains the following license and notice below:
+
+MIT License
+
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 -----------
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@testing-library/user-event": "^14.4.3",
         "@types/jest": "^29.5.1",
         "@types/react": "^18.2.7",
-        "@yext/chat-headless-react": "^0.9.1",
+        "@yext/chat-headless-react": "^0.9.5",
         "@yext/eslint-config": "^1.0.2",
         "babel-jest": "^29.5.0",
         "eslint": "^8.39.0",
@@ -59,7 +59,7 @@
         "typescript": "^5.0.4"
       },
       "peerDependencies": {
-        "@yext/chat-headless-react": "^0.9.1",
+        "@yext/chat-headless-react": "^0.9.5",
         "react": "^16.14 || ^17 || ^18",
         "react-dom": "^16.14 || ^17 || || ^18"
       }
@@ -4638,6 +4638,7 @@
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.7.tgz",
       "integrity": "sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "immer": "^9.0.21",
         "redux": "^4.2.1",
@@ -7413,10 +7414,11 @@
       }
     },
     "node_modules/@types/hoist-non-react-statics": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz",
-      "integrity": "sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.6.tgz",
+      "integrity": "sha512-lPByRJUer/iN/xa4qpyL0qmL11DqNW81iU/IG1S3uvRUq4oKagz8VCxZjiWkumgt66YT3vOdDgZ0o32sGKtCEw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
@@ -7686,7 +7688,8 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
       "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.24",
@@ -8085,43 +8088,46 @@
       }
     },
     "node_modules/@yext/analytics": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@yext/analytics/-/analytics-0.6.6.tgz",
-      "integrity": "sha512-LdGE0ZIE295+p/kCW/ps9XKp5M2gn+AM5pDlqzx13nzNKxI4eyOVKtpRwRNroFldIx9sQHVK7uvyQtGshWWB9g==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@yext/analytics/-/analytics-1.0.1.tgz",
+      "integrity": "sha512-D8ahIRIVtdvV7Ycup13OY930waOzi50gzwXO7Cpa4SK0+eREg3YMxsNxbXpgXVoEdwKaMw/xhsKy3Cy0fTcQZA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "cross-fetch": "^3.1.5",
         "ulidx": "^2.0.0"
       }
     },
     "node_modules/@yext/chat-core": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@yext/chat-core/-/chat-core-0.8.2.tgz",
-      "integrity": "sha512-+ivq2xEHY1sGLOlPQ7d5wnlswsZfdO/Hz1Y8cmgq5UP6cpr4wUBTTQd5yWn1u9JJHq38/jcRleC2TSrh8E2Ozg==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@yext/chat-core/-/chat-core-0.9.1.tgz",
+      "integrity": "sha512-rJIO7ZFmkBUecrPWNFu2Sqx7rRWR9Uxy/E7FWVjHsMoV4hjcqKxMZzO6sHq1Q5ZT95FLMjx2VJzepmaCBF2j7A==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
     },
     "node_modules/@yext/chat-headless": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@yext/chat-headless/-/chat-headless-0.10.1.tgz",
-      "integrity": "sha512-CuJw7IdPo3ZE8SdypgDuSDEMpnYsRgjKf4ZYF+a4qxNLlgs5wsORzKiqxo6PmK/+yf3A71s0nwVHGxvVlT4YQA==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@yext/chat-headless/-/chat-headless-0.12.2.tgz",
+      "integrity": "sha512-Y9+ZBlTaoWfkDP+LEGT5bjXT10rGV2V13DkL5o0iWTkP27PIbsabEaanO3G+hjbPi0DBr5vULodAD6FyGRlD0A==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
-        "@yext/analytics": "^0.6.3",
-        "@yext/chat-core": "^0.8.2"
+        "@yext/analytics": "^1.0.1",
+        "@yext/chat-core": "^0.9.1"
       }
     },
     "node_modules/@yext/chat-headless-react": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@yext/chat-headless-react/-/chat-headless-react-0.9.1.tgz",
-      "integrity": "sha512-tRfi4isVzAYGrJL1ikz+bCEsk4cTkZgLO/K0Sk48Et/AyixWsdfFy+JaP8NGpnB1OZH2n7lVkRB7R80bzhMUjg==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@yext/chat-headless-react/-/chat-headless-react-0.9.5.tgz",
+      "integrity": "sha512-XZU6MhLqWKrqwt1hoPGIxg9evKSbn0tsXNTqa+RZKiFfEtW17qfWRe1MddarT0dA2vSAnLPKXW9KFduCK3PSiw==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
-        "@yext/chat-headless": "^0.10.1",
+        "@yext/chat-headless": "^0.12.2",
         "react-redux": "^8.0.5"
       },
       "peerDependencies": {
@@ -9701,12 +9707,13 @@
       }
     },
     "node_modules/cross-fetch": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
-      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "node-fetch": "^2.6.12"
+        "node-fetch": "^2.7.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -12707,6 +12714,7 @@
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "react-is": "^16.7.0"
       }
@@ -12715,7 +12723,8 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
@@ -12874,6 +12883,7 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
       "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -15866,10 +15876,11 @@
       }
     },
     "node_modules/layerr": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/layerr/-/layerr-2.1.0.tgz",
-      "integrity": "sha512-xDD9suWxfBYeXgqffRVH/Wqh+mqZrQcqPRn0I0ijl7iJQ7vu8gMGPt1Qop59pEW/jaIDNUN7+PX1Qk40+vuflg==",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/layerr/-/layerr-3.0.0.tgz",
+      "integrity": "sha512-tv754Ki2dXpPVApOrjTyRo4/QegVb9eVFq4mjqp4+NM5NaX7syQvN5BBNfV/ZpAHCEHV24XdUVrBAoka4jt3pA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lazy-universal-dotenv": {
       "version": "4.0.0",
@@ -17014,10 +17025,11 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -18535,6 +18547,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
       "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.1",
         "@types/hoist-non-react-statics": "^3.3.1",
@@ -18879,6 +18892,7 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
       "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
@@ -18888,6 +18902,7 @@
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
       "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "redux": "^4"
       }
@@ -19108,7 +19123,8 @@
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
       "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.2",
@@ -20671,12 +20687,13 @@
       }
     },
     "node_modules/ulidx": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/ulidx/-/ulidx-2.3.0.tgz",
-      "integrity": "sha512-36piWNqcdp9hKlQewyeehCaALy4lyx3FodsCxHuV6i0YdexSkjDOubwxEVr2yi4kh62L/0MgyrxqG4K+qtovnw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/ulidx/-/ulidx-2.4.1.tgz",
+      "integrity": "sha512-xY7c8LPyzvhvew0Fn+Ek3wBC9STZAuDI/Y5andCKi9AX6/jvfaX45PhsDX8oxgPL0YFp0Jhr8qWMbS/p9375Xg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "layerr": "^2.0.1"
+        "layerr": "^3.0.0"
       },
       "engines": {
         "node": ">=16"
@@ -21041,12 +21058,13 @@
       "dev": true
     },
     "node_modules/use-sync-external-store": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
-      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
+      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@testing-library/user-event": "^14.4.3",
     "@types/jest": "^29.5.1",
     "@types/react": "^18.2.7",
-    "@yext/chat-headless-react": "^0.9.1",
+    "@yext/chat-headless-react": "^0.9.5",
     "@yext/eslint-config": "^1.0.2",
     "babel-jest": "^29.5.0",
     "eslint": "^8.39.0",
@@ -91,7 +91,7 @@
     "typescript": "^5.0.4"
   },
   "peerDependencies": {
-    "@yext/chat-headless-react": "^0.9.1",
+    "@yext/chat-headless-react": "^0.9.5",
     "react": "^16.14 || ^17 || ^18",
     "react-dom": "^16.14 || ^17 || || ^18"
   },

--- a/test-site/package-lock.json
+++ b/test-site/package-lock.json
@@ -23,7 +23,7 @@
     },
     "..": {
       "name": "@yext/chat-ui-react",
-      "version": "0.11.4",
+      "version": "0.12.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-markdown": "^6.0.3",
@@ -54,7 +54,7 @@
         "@testing-library/user-event": "^14.4.3",
         "@types/jest": "^29.5.1",
         "@types/react": "^18.2.7",
-        "@yext/chat-headless-react": "^0.9.1",
+        "@yext/chat-headless-react": "^0.9.5",
         "@yext/eslint-config": "^1.0.2",
         "babel-jest": "^29.5.0",
         "eslint": "^8.39.0",
@@ -76,7 +76,7 @@
         "typescript": "^5.0.4"
       },
       "peerDependencies": {
-        "@yext/chat-headless-react": "^0.9.1",
+        "@yext/chat-headless-react": "^0.9.5",
         "react": "^16.14 || ^17 || ^18",
         "react-dom": "^16.14 || ^17 || || ^18"
       }

--- a/test-site/src/App.tsx
+++ b/test-site/src/App.tsx
@@ -5,15 +5,30 @@ import {
 } from "@yext/chat-headless-react";
 import { useState } from "react";
 
+/**
+ * The analytics SDK only supports the SANDBOX and PRODUCTION environments. If you want to test
+ * chat with analytics events, set testEnvironment to SANDBOX.
+ * */
+const testEnvironment = 'DEV';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+const chatEndpoint = testEnvironment === 'SANDBOX'
+    ?  `https://sbx-cdn.us.yextapis.com/v2/accounts/me/chat/${process.env.REACT_APP_TEST_BOT_ID}/message`
+    : `https://liveapi-dev.yext.com/v2/accounts/me/chat/${process.env.REACT_APP_TEST_BOT_ID}/message`;
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+const chatStreamEndpoint = testEnvironment === 'SANDBOX'
+    ? `https://sbx-cdn.us.yextapis.com/v2/accounts/me/chat/${process.env.REACT_APP_TEST_BOT_ID}/message/streaming`
+    : `https://liveapi-dev.yext.com/v2/accounts/me/chat/${process.env.REACT_APP_TEST_BOT_ID}/message/streaming`;
+
 const config: HeadlessConfig = {
   botId: process.env.REACT_APP_TEST_BOT_ID || "BOT_ID_HERE",
   apiKey: process.env.REACT_APP_BOT_API_KEY || "BOT_KEY_HERE",
+  env: 'SANDBOX',
+  region: 'US',
   endpoints: {
-    chat: `https://liveapi-dev.yext.com/v2/accounts/me/chat/${process.env.REACT_APP_TEST_BOT_ID}/message`,
-    chatStream: `https://liveapi-dev.yext.com/v2/accounts/me/chat/${process.env.REACT_APP_TEST_BOT_ID}/message/streaming`,
-  },
-  analyticsConfig: {
-    endpoint: "https://www.dev.us.yextevents.com/accounts/me/events",
+    chat: chatEndpoint,
+    chatStream: chatStreamEndpoint,
   },
   saveToLocalStorage: true,
 };

--- a/tests/__utils__/mocks.ts
+++ b/tests/__utils__/mocks.ts
@@ -76,6 +76,6 @@ export function mockChatAnalytics(
       report: jest.fn(),
     }));
   return jest
-    .spyOn(require("@yext/analytics"), "provideChatAnalytics")
+    .spyOn(require("@yext/analytics"), "analytics")
     .mockImplementation(mockImpl as (...args: unknown[]) => unknown);
 }


### PR DESCRIPTION
Updates chat-ui-react to use chat-headless-react v0.9.5, allowing us to use the latest version of yext/analytics

J=WAT-4671
TEST=auto, manual

Unit and integration tests pass.
Spun up test-site locally with sandbox model. Was able to make requests and receive responses as expected, confirmed analytics events were going through for responses, impressions, and link clicks.