### PR TITLE
fix: add prepack build step before npm publish (v0.13.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "build:css": "./scoped-bundle.sh",
     "build:js": "rollup --config rollup.config.mjs",
     "build": "rm -rf lib/** && npm run build:js && npm run build:css && npm run generate-docs && npm run generate-notices",
+    "prepack": "npm run build",
     "build-storybook": "storybook build"
   },
   "repository": {


### PR DESCRIPTION
When we switch to the trusted publishing workflow, published versions are missing lib artifacts even though package.json exports and consumers expect files like lib/commonjs/src/index.js and lib/bundle.css